### PR TITLE
Add default host that can be overridden and NuCivic private config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,6 @@
 data_starter:
   version: 1.12.8.0
 
+acquia:
+  search:
+    host: useast1-c1.acquia-search.com


### PR DESCRIPTION
REF CIVIC-3955
# Description

This is an anticipation to change where we will merge config.yml with
config/config.yml to produce the final config/config.php source:

We will have a working search host default, while allowing the upstream to
change it.

We also want to pull in private config as well. Maybe we should have an explicit "config.private.yml" file as well or something.
# AC
- [ ] config.yml can be used for config with config/config.yml providing overrides
