### PR TITLE
Don't ignore dkan/test/assets folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # Ignore the dkan test composer folder.
 /docroot/profiles/dkan/test/vendor
 /docroot/profiles/dkan/test/assets
+!/docroot/profiles/dkan/test/assets/README.md
 
 # Packages #
 ############


### PR DESCRIPTION
Ignoring dkan/test/assets will cause CIRCLE to throw a build error.
