### PR TITLE
Temporarily revert ahoy2 switch

### DIFF
--- a/.ahoy/site/.ahoy.yml
+++ b/.ahoy/site/.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 usage: NuCivic Data cli app for development using ahoy.
 commands:
   drush:
@@ -7,26 +7,22 @@ commands:
 
   build:
     usage: A series of commands for dkan development.
-    imports:
-      - .ahoy/site/build.ahoy.yml
+    import: .ahoy/site/build.ahoy.yml
     hide: true
 
   dkan:
     usage: A series of commands for dkan development.
     hide: true
-    imports:
-      - dkan/.ahoy/dkan.ahoy.yml
+    import: dkan/.ahoy/dkan.ahoy.yml
 
   diagnose:
     usage: A series of ahoy-docker setup diagnosis commands.
-    imports:
-      - dkan/.ahoy/diagnose.ahoy.yml
+    import: dkan/.ahoy/diagnose.ahoy.yml
     hide: true
 
   doctor:
     usage: A series of ahoy-docker setup diagnosis commands.
-    imports:
-      - dkan/.ahoy/diagnose.ahoy.yml
+    import: dkan/.ahoy/diagnose.ahoy.yml
     hide: true
 
   confirm:
@@ -35,8 +31,7 @@ commands:
 
   docker:
     usage: A series of docker commands for dkan development (experimental)
-    imports:
-      - dkan/.ahoy/docker.ahoy.yml
+    import: dkan/.ahoy/docker.ahoy.yml
     hide: false 
 
   init:
@@ -55,46 +50,36 @@ commands:
 
   ci:
     usage: A series of commands to handle ci setup
-    imports:
-      - .ahoy/site/ci.ahoy.yml
-      - config/.ahoy/site/ci.ahoy.yml
+    import: .ahoy/site/ci.ahoy.yml
     hide: true
 
   tools:
     usage: A series of commands to setup dev tools
-    imports:
-      - .ahoy/site/tools.ahoy.yml
+    import: .ahoy/site/tools.ahoy.yml
     hide: true
 
   debug:
     usage: A series of commands to setup debugging
-    imports:
-      - .ahoy/site/debug.ahoy.yml
+    import: .ahoy/site/debug.ahoy.yml
     hide: true
 
   launch-checklist:
     usage: A series of commands to handle pre launch checks
-    imports:
-      - .ahoy/site/launch-checklist.ahoy.yml
+    import: .ahoy/site/launch-checklist.ahoy.yml
     hide: true
 
   site:
     usage: A series of commands for site development
-    imports:
-      - .ahoy/site/site.ahoy.yml
-      - config/.ahoy/site/site.ahoy.yml
+    import: .ahoy/site/site.ahoy.yml
 
   utils:
     hide: true
     usage: A series of helper commands (hide the details)
-    imports:
-      - .ahoy/site/utils.ahoy.yml
-      - config/.ahoy/site/utils.ahoy.yml
+    import: .ahoy/site/utils.ahoy.yml
 
   remote:
     usage: A series of commands for site remote management
-    imports:
-      - .ahoy/site/remote.ahoy.yml
+    import: .ahoy/site/remote.ahoy.yml
     hide: true
 
   parse:

--- a/.ahoy/site/build.ahoy.yml
+++ b/.ahoy/site/build.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   drupal-rebuild:

--- a/.ahoy/site/ci.ahoy.yml
+++ b/.ahoy/site/ci.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   setup:

--- a/.ahoy/site/debug.ahoy.yml
+++ b/.ahoy/site/debug.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   setup-sublime:

--- a/.ahoy/site/launch-checklist.ahoy.yml
+++ b/.ahoy/site/launch-checklist.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   run:

--- a/.ahoy/site/remote.ahoy.yml
+++ b/.ahoy/site/remote.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   reinstall:
@@ -43,5 +43,4 @@ commands:
 
   launch-checklist:
     usage: A series of commands to perform a launch-checklist
-    import:
-      - .ahoy/site/launch-checklist.ahoy.yml
+    import: .ahoy/site/launch-checklist.ahoy.yml

--- a/.ahoy/site/site.ahoy.yml
+++ b/.ahoy/site/site.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   up:

--- a/.ahoy/site/tools.ahoy.yml
+++ b/.ahoy/site/tools.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   dnsmasq:

--- a/.ahoy/site/utils.ahoy.yml
+++ b/.ahoy/site/utils.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   setup:

--- a/config/.ahoy/site/ci.ahoy.yml
+++ b/config/.ahoy/site/ci.ahoy.yml
@@ -1,2 +1,2 @@
-ahoyapi: v2
+ahoyapi: v1
 commands:

--- a/config/.ahoy/site/site.ahoy.yml
+++ b/config/.ahoy/site/site.ahoy.yml
@@ -1,2 +1,2 @@
-ahoyapi: v2
+ahoyapi: v1
 commands:

--- a/config/.ahoy/site/utils.ahoy.yml
+++ b/config/.ahoy/site/utils.ahoy.yml
@@ -1,2 +1,2 @@
-ahoyapi: v2
+ahoyapi: v1
 commands:

--- a/dkan/.ahoy/diagnose.ahoy.yml
+++ b/dkan/.ahoy/diagnose.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   all:

--- a/dkan/.ahoy/dkan.ahoy.yml
+++ b/dkan/.ahoy/dkan.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   drupal-rebuild:
@@ -181,8 +181,7 @@ commands:
 
   theme:
     usage: A series of commands for dkan theme development
-    imports:
-      - dkan/.ahoy/theme.ahoy.yml
+    import: dkan/.ahoy/theme.ahoy.yml
     hide: true
 
   uli:

--- a/dkan/.ahoy/docker-compose.yml
+++ b/dkan/.ahoy/docker-compose.yml
@@ -43,7 +43,7 @@ db:
 # Used for all console commands and tools.
 cli:
   hostname: cli
-  image: nuams/drupal-cli:civic-4262_add-ahoyv2-to-docker
+  image: nuams/drupal-cli:v0.10.2
   environment:
     - XDEBUG_CONFIG=idekey=cli
     - PHP_IDE_CONFIG=serverName=dkan.docker

--- a/dkan/.ahoy/docker.ahoy.yml
+++ b/dkan/.ahoy/docker.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   env:

--- a/dkan/.ahoy/starter.ahoy.yml
+++ b/dkan/.ahoy/starter.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 usage: DKAN cli app for development using ahoy.
 commands:
 
@@ -8,8 +8,7 @@ commands:
 
   dkan:
     usage: A series of commands for dkan development.
-    imports:
-      - dkan/.ahoy/dkan.ahoy.yml
+    import: dkan/.ahoy/dkan.ahoy.yml
 
 # Utility / Experimental commands that are currently hidden
   confirm:
@@ -18,8 +17,7 @@ commands:
 
   docker:
     usage: A series of docker commands for dkan development (experimental)
-    imports:
-      - dkan/.ahoy/docker.ahoy.yml
+    import: dkan/.ahoy/docker.ahoy.yml
     hide: true
 
   init:
@@ -38,12 +36,10 @@ commands:
 
   diagnose:
     usage: A series of maintenance commands to check the docker environment health
-    imports:
-      - dkan/.ahoy/diagnose.ahoy.yml
+    import: dkan/.ahoy/diagnose.ahoy.yml
     hide: true
 
   doctor:
     usage: A series of maintenance commands to check the docker environment health (Deprecated and moved to diagnose commands)
-    imports:
-      - dkan/.ahoy/diagnose.ahoy.yml
+    import: dkan/.ahoy/diagnose.ahoy.yml
     hide: true

--- a/dkan/.ahoy/theme.ahoy.yml
+++ b/dkan/.ahoy/theme.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
   fetch:

--- a/dkan/.ahoy/utils.ahoy.yml
+++ b/dkan/.ahoy/utils.ahoy.yml
@@ -1,4 +1,4 @@
-ahoyapi: v2
+ahoyapi: v1
 version: 0.0.0
 commands:
     confirm:

--- a/dkan/dkan-init.sh
+++ b/dkan/dkan-init.sh
@@ -140,7 +140,7 @@ install_dependencies() {
 
   if [ ! "$(which ahoy)" ]; then
     echo "> Installing Ahoy";
-    version=2.0.0-alpha
+    version=1.1.0
     os=`uname -s | tr '[:upper:]' '[:lower:]'`
     $AUTO_SUDO wget -q https://nucivic-binaries.s3-us-west-1.amazonaws.com/ahoy/$version/ahoy-$os-amd64  -O /usr/local/bin/ahoy -O /usr/local/bin/ahoy &&
     $AUTO_SUDO chown $this_user /usr/local/bin/ahoy &&

--- a/docs/docker-dev-env/ahoy.md
+++ b/docs/docker-dev-env/ahoy.md
@@ -27,6 +27,10 @@ DKAN's ahoy commands are stored in the ``.ahoy/`` folder in DKAN.
 
 DKAN Starter ahoy commands are stored in the ``.ahoy/sites/`` folder in DKAN.
 
+# TODO: enable ahoy v2
+Everything below this line is currently not yet available.
+---
+
 ## Upgrading to ahoy v2
 ### Rational
 Now that dkan_starter is open sourced we need a straight forward way of allowing


### PR DESCRIPTION
Description
===
There are too many changes in the next release of dkan_starter.  We are
retracting the ahoy2 switch to give us more time to switch over our current
sites to the new dkan_starter structure including major changes to where the
site ahoy commands are stored.