### PR TITLE
Shield should never be on in the local instance.

### DIFF
--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -193,6 +193,7 @@ switch(ENVIRONMENT) {
       'search_api_acquia',
       'securepages',
       'syslog',
+      'shield',
     );
     // Show ALL errors when working locally.
     $conf['error_level'] = ERROR_REPORTING_DISPLAY_ALL;


### PR DESCRIPTION
When shield get's enabled on the production DB it makes builds fail in Circle.