### PR TITLE
Truncates cache_bootstrap during deployment

### DIFF
--- a/hooks/common/post-code-update/drush-env-switch.sh
+++ b/hooks/common/post-code-update/drush-env-switch.sh
@@ -30,6 +30,8 @@ done
 
 echo "Target environment is $target_env"
 
+echo "Truncates cache_bootstrap"
+drush @$drush_alias sqlq "TRUNCATE cache_bootstrap;"
 echo "Running drush rr --no-cache-clear"
 drush @$drush_alias rr --no-cache-clear
 echo "Truncating cache table"


### PR DESCRIPTION
## Description
This fixes issue like: 

```
include_once(/home/ubuntu/ga_reports/docroot/sites/all/modules/contrib/entity/includes/entity.controller.inc):  [warning]
failed to open stream: No such file or directory bootstrap.inc:3454
```

which get tripped before registry rebuild.