### PR TITLE
Make assets/sites/default writable locally.

### DIFF
--- a/.ahoy/site/.scripts/site.files-fix-permissions.sh
+++ b/.ahoy/site/.scripts/site.files-fix-permissions.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 mkdir -p docroot/sites/default/files
+chmod 777 assets/sites/default
 
 if [ -d docroot/sites/default/files ]; then
   find docroot/sites/default/files/ -type d -exec chmod o+rwx {} \;


### PR DESCRIPTION
Fixes error thrown locally due to folder permissions.

REF CIVIC-4787

QA Steps
- [x] Locally you can switch branch even if change without getting permission error for assets/sites/default folder