### PR TITLE
WIP Adds additional option for builds that don't had dkan_acquia_search_s…

### DIFF
--- a/hooks/common/post-code-update/drush-env-switch.sh
+++ b/hooks/common/post-code-update/drush-env-switch.sh
@@ -49,7 +49,7 @@ if [[ "$drupal" =~ "Successful" ]]; then
   drush @$drush_alias -y fr --force custom_config
   drush @$drush_alias env-switch $target_env --force
   drush @$drush_alias -y updb
-  DB_BASED_SEARCH=`drush @$drush_alias pmi dkan_acquia_search_solr | grep -e 'disabled|not found'`
+  DB_BASED_SEARCH=`drush @$drush_alias pmi dkan_acquia_search_solr | grep -E 'disabled|not found'`
   if [ -z "$DB_BASED_SEARCH" ]; then
     echo "SOLR Search, avoiding indexing data"
   else

--- a/hooks/common/post-code-update/drush-env-switch.sh
+++ b/hooks/common/post-code-update/drush-env-switch.sh
@@ -49,7 +49,7 @@ if [[ "$drupal" =~ "Successful" ]]; then
   drush @$drush_alias -y fr --force custom_config
   drush @$drush_alias env-switch $target_env --force
   drush @$drush_alias -y updb
-  DB_BASED_SEARCH=`drush @$drush_alias pmi dkan_acquia_search_solr | grep disabled`
+  DB_BASED_SEARCH=`drush @$drush_alias pmi dkan_acquia_search_solr | grep -e 'disabled|not found'`
   if [ -z "$DB_BASED_SEARCH" ]; then
     echo "SOLR Search, avoiding indexing data"
   else


### PR DESCRIPTION
## Description
If dkan_acquia_search_solr is not present in the build the environment-switch concludes that the site is using solr search. The contrary should happen.

Need this for usda CI. 