### PR TITLE
Civic 4978: add ga codes in config.yml

### DIFF
--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -149,6 +149,10 @@ if (_data_starter_validates('stage_file_proxy_origin')) {
 // KEY for dkan health status
 $conf['dkan_health_status_health_api_access_key'] = 'DKAN_HEALTH';
 
+// Add tracking codes for Google Analytics.
+$conf['googleanalytics_account'] = $conf['gaClientTrackingCode'];
+$conf['googleanalytics_codesnippet_after'] = "ga('create', '" . $conf['gaNuCivicTrackingCode'] . "', 'nucivicTracker');ga('nucivicTracker.send', 'pageview');";
+
 /******************************************************
  * OPTIONAL: Override default settings per environment.
  ******************************************************/

--- a/config/config.php
+++ b/config/config.php
@@ -7,7 +7,7 @@
 $conf = array (
   'default' => 
   array (
-    'hostname' => 'localhost',
+    'hostname' => 'www.example.com',
     'https_everywhere' => false,
     'https_securepages' => false,
     'clamav' => 
@@ -21,6 +21,11 @@ $conf = array (
       'limit' => '10MB',
       'queue' => '50MB',
     ),
+  ),
+  'redirectDomains' => 
+  array (
+    0 => 'example.com',
+    1 => 'oldsite.example.com',
   ),
   'private' => 
   array (
@@ -66,4 +71,6 @@ $conf = array (
       'derived_key' => 'changeme',
     ),
   ),
+  'gaClientTrackingCode' => 'UA-XXXXX-Y',
+  'gaNuCivicTrackingCode' => 'UA-XXXXX-Z',
 );

--- a/config/config.yml
+++ b/config/config.yml
@@ -40,3 +40,6 @@ acquia:
     base_url: http://produrl
     core_id: changeme
     derived_key: changeme
+
+gaClientTrackingCode: UA-XXXXX-Y
+gaNuCivicTrackingCode: UA-XXXXX-Z


### PR DESCRIPTION
## Description

We need to add the GA code(s) to config.yml.
If we are able to add two codes then we should be able to set them in config.yml and then the snippet required could be set in setting.php as a variable with each tracking code included.


## QA Tests
>Add step by step instructions needed to QA the completed work from the user's perspective.
>If there is no user impact, list any steps needed for a code review beyond the information added to the description.
