### PR TITLE
Adds support for private files if available in s3 backup

### DIFF
--- a/.ahoy/site/.scripts/site.files-fix-permissions.sh
+++ b/.ahoy/site/.scripts/site.files-fix-permissions.sh
@@ -8,8 +8,6 @@ if [ -d docroot/sites/default/files ]; then
   find docroot/sites/default/files/ -type f -exec chmod o+rw {} \;
 fi
 
-mkdir -p docroot/sites/default/private
-
 if [ -d docroot/sites/default/private]; then
   find docroot/sites/default/private/ -type d -exec chmod o+rwx {} \;
   find docroot/sites/default/private/ -type f -exec chmod o+rw {} \;

--- a/.ahoy/site/.scripts/site.files-fix-permissions.sh
+++ b/.ahoy/site/.scripts/site.files-fix-permissions.sh
@@ -8,7 +8,7 @@ if [ -d docroot/sites/default/files ]; then
   find docroot/sites/default/files/ -type f -exec chmod o+rw {} \;
 fi
 
-if [ -d docroot/sites/default/private]; then
+if [ -d docroot/sites/default/private ]; then
   find docroot/sites/default/private/ -type d -exec chmod o+rwx {} \;
   find docroot/sites/default/private/ -type f -exec chmod o+rw {} \;
 fi

--- a/.ahoy/site/.scripts/site.files-fix-permissions.sh
+++ b/.ahoy/site/.scripts/site.files-fix-permissions.sh
@@ -7,3 +7,10 @@ if [ -d docroot/sites/default/files ]; then
   find docroot/sites/default/files/ -type d -exec chmod o+rwx {} \;
   find docroot/sites/default/files/ -type f -exec chmod o+rw {} \;
 fi
+
+mkdir -p docroot/sites/default/private
+
+if [ -d docroot/sites/default/private]; then
+  find docroot/sites/default/private/ -type d -exec chmod o+rwx {} \;
+  find docroot/sites/default/private/ -type f -exec chmod o+rw {} \;
+fi

--- a/.ahoy/site/utils.ahoy.yml
+++ b/.ahoy/site/utils.ahoy.yml
@@ -172,7 +172,16 @@ commands:
 
   files-link:
     usage: Links files.
-    cmd: ahoy cmd-proxy ln -s ../../../$(ahoy utils name).prod.files/files docroot/sites/default/files
+    cmd: |
+      ASSET_FILE_DIR="$(ahoy site name).prod.files"
+      rm -rf docroot/sites/default/files
+      rm -rf docroot/sites/default/private
+      if [ -d "$ASSET_FILE_DIR/files" ]; then
+        ahoy cmd-proxy ln -s ../../../$(ahoy site name).prod.files/files docroot/sites/default/files
+      fi
+      if [ -d "$ASSET_FILE_DIR/private" ]; then
+        ahoy cmd-proxy ln -s ../../../$(ahoy site name).prod.files/private docroot/sites/default/private
+      fi
     hide: true
 
   files-fix-permissions:


### PR DESCRIPTION
This checks for a `private` folder next to the `files` folder in the s3 file tar. If it's there, it creates a symlink as it does for the file folder at `docroot/sites/default`
