### PR TITLE
Fix ahoy build update.

### DIFF
--- a/.ahoy/site/build.ahoy.yml
+++ b/.ahoy/site/build.ahoy.yml
@@ -260,8 +260,7 @@ commands:
       mv config .config
       rm -rf * .ahoy .ahoy.yml .github .probo.public.yml .probo.yml
       # You can rsync now
-      rsync -av --exclude=.git .dkan_starter/ ./
-      git checkout -- config
+      rsync -av --exclude=.git --exclude=.dkan_starter .dkan_starter/ ./
       rm -rf config
       mv .config config
       rm -rf .dkan_starter


### PR DESCRIPTION
rsync is overriding .dkan_starter during build and causing errors.