### PR TITLE
Typo in ahoy utils files-link

### DIFF
--- a/.ahoy/site/utils.ahoy.yml
+++ b/.ahoy/site/utils.ahoy.yml
@@ -173,14 +173,14 @@ commands:
   files-link:
     usage: Links files.
     cmd: |
-      ASSET_FILE_DIR="$(ahoy site name).prod.files"
+      ASSET_FILE_DIR="$(ahoy utils name).prod.files"
       rm -rf docroot/sites/default/files
       rm -rf docroot/sites/default/private
       if [ -d "$ASSET_FILE_DIR/files" ]; then
-        ahoy cmd-proxy ln -s ../../../$(ahoy site name).prod.files/files docroot/sites/default/files
+        ahoy cmd-proxy ln -s ../../../$(ahoy utils name).prod.files/files docroot/sites/default/files
       fi
       if [ -d "$ASSET_FILE_DIR/private" ]; then
-        ahoy cmd-proxy ln -s ../../../$(ahoy site name).prod.files/private docroot/sites/default/private
+        ahoy cmd-proxy ln -s ../../../$(ahoy utils name).prod.files/private docroot/sites/default/private
       fi
     hide: true
 


### PR DESCRIPTION
## Description

`ahoy utils files-link` was using `ahoy site name` instead of `ahoy utils name`
