### PR TITLE
Always allow cli access.

### DIFF
--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -153,6 +153,9 @@ $conf['dkan_health_status_health_api_access_key'] = 'DKAN_HEALTH';
 $conf['googleanalytics_account'] = $conf['gaClientTrackingCode'];
 $conf['googleanalytics_codesnippet_after'] = "ga('create', '" . $conf['gaNuCivicTrackingCode'] . "', 'nucivicTracker');ga('nucivicTracker.send', 'pageview');";
 
+// Never disallow cli access via shield config.
+$conf['shield_allow_cli'] = 1;
+
 /******************************************************
  * OPTIONAL: Override default settings per environment.
  ******************************************************/


### PR DESCRIPTION
We cannot disable drush access to sites using shield configuration.

REF: https://jira.govdelivery.com/browse/CIVIC-5231

QA Steps
==
- [x] enable shield and try to configure disallow cli access... this should not be possible.