### PR TITLE
Run freshclam after installing clamav

### DIFF
--- a/.probo.yml
+++ b/.probo.yml
@@ -33,6 +33,8 @@ steps:
       time bash dkan/dkan-init.sh dkan --deps-only
       sudo apt-get update
       sudo apt-get install libdigest-hmac-perl clamav clamav-freshclam -y
+      # Clamav need virus database to function.
+      freshclam
 
       echo ""
       echo "-------> Setup the settings.local.php file and install a fresh database."


### PR DESCRIPTION
USDA faced a problem uploading local files to resources due to a clamav issue.

![image](https://cloud.githubusercontent.com/assets/1914306/21826217/ef8693f0-d786-11e6-92dd-63aacda3d0a7.png)

clamav is looking for viruses definitions. Those are downloaded by runing `freshclam`.