### PR TITLE
Clean up db when vis_entity modules are disabled CIVIC-5290

### DIFF
--- a/assets/modules/data_config/data_config.install
+++ b/assets/modules/data_config/data_config.install
@@ -1,9 +1,101 @@
 <?php
 
 /**
+ * @file
+ * Additional setup tasks for DKAN.
+ */
+
+/**
  * Removes dkan_default_content.
  */
 function data_config_update_7001() {
   module_disable(array("dkan_default_content"));
   drupal_uninstall_modules(array("dkan_default_content"));
+}
+
+/**
+ * Remove disabled visualization menu links.
+ */
+function data_config_update_7002() {
+
+  if (!module_exists('visualization_entity_choropleth_bundle')) {
+    // Remove choropleth bundle.
+    db_delete('eck_bundle')
+      ->condition('name', 'choropleth_visualization')
+      ->execute();
+    // Remove choropleth links.
+    $query = db_select('menu_links', 'm');
+    $query->fields('m', array('mlid'));
+    $query->condition('link_path', '%' . db_like('choropleth') . '%', 'LIKE');
+    $result = $query->execute();
+    if ($result) {
+      foreach ($result as $value) {
+        db_delete('menu_links')
+          ->condition('mlid', $value->mlid)
+          ->execute();
+        $messages[] = $value->mlid . ' choropleth link deleted';
+      }
+    }
+    if (menu_rebuild()) {
+      drupal_flush_all_caches();
+      $messages[] = t('menu rebuilt');
+    }
+  }
+
+  if (!module_exists('visualization_entity_geojson_bundle')) {
+    // Remove choropleth bundle.
+    db_delete('eck_bundle')
+      ->condition('name', 'geojson_visualization')
+      ->execute();
+    // Remove choropleth links.
+    $query = db_select('menu_links', 'm');
+    $query->fields('m', array('mlid'));
+    $query->condition('link_path', '%' . db_like('geojson_visualization') . '%', 'LIKE');
+    $result = $query->execute();
+    if ($result) {
+      foreach ($result as $value) {
+        db_delete('menu_links')
+          ->condition('mlid', $value->mlid)
+          ->execute();
+        $messages[] = $value->mlid . ' geojson link deleted';
+      }
+    }
+    if (menu_rebuild()) {
+      drupal_flush_all_caches();
+      $messages[] = t('menu rebuilt');
+    }
+  }
+
+  if (!module_exists('geo_file_entity')) {
+    // Remove geo_file residuals.
+    db_delete('eck_bundle')
+      ->condition('name', 'geojson')
+      ->execute();
+    db_delete('eck_entity_type')
+      ->condition('name', 'geo_file')
+      ->execute();
+    db_drop_table('eck_geo_file');
+    db_drop_table('field_data_field_ve_geojson_key');
+    db_drop_table('field_data_field_ve_geojson_value');
+    db_drop_table('field_revision_field_ve_geojson_key');
+    db_drop_table('field_revision_field_ve_geojson_value');
+    // Remove geo_file links.
+    $query = db_select('menu_links', 'm');
+    $query->fields('m', array('mlid'));
+    $query->condition('link_path', '%' . db_like('geo_file') . '%', 'LIKE');
+    $result = $query->execute();
+    if ($result) {
+      foreach ($result as $value) {
+        db_delete('menu_links')
+          ->condition('mlid', $value->mlid)
+          ->execute();
+        $messages[] = $value->mlid . ' geo_file link deleted';
+      }
+    }
+    if (menu_rebuild()) {
+      drupal_flush_all_caches();
+      $messages[] = t('menu rebuilt');
+    }
+  }
+  return $messages;
 }

--- a/assets/modules/data_config/data_config.install
+++ b/assets/modules/data_config/data_config.install
@@ -36,10 +36,6 @@ function data_config_update_7002() {
         $messages[] = $value->mlid . ' choropleth link deleted';
       }
     }
-    if (menu_rebuild()) {
-      drupal_flush_all_caches();
-      $messages[] = t('menu rebuilt');
-    }
   }
 
   if (!module_exists('visualization_entity_geojson_bundle')) {
@@ -59,10 +55,6 @@ function data_config_update_7002() {
           ->execute();
         $messages[] = $value->mlid . ' geojson link deleted';
       }
-    }
-    if (menu_rebuild()) {
-      drupal_flush_all_caches();
-      $messages[] = t('menu rebuilt');
     }
   }
 
@@ -92,10 +84,10 @@ function data_config_update_7002() {
         $messages[] = $value->mlid . ' geo_file link deleted';
       }
     }
-    if (menu_rebuild()) {
-      drupal_flush_all_caches();
-      $messages[] = t('menu rebuilt');
-    }
+  }
+  if (menu_rebuild()) {
+    drupal_flush_all_caches();
+    $messages[] = t('menu rebuilt');
   }
   return $messages;
 }


### PR DESCRIPTION
## Description
DKAN used to ship with all visualization entity modules enabled, currently we only enable charts OOB. Older client databases will have residual items from disabled visualization modules and we need to clear it out. 

## QA Tests (Test against North Dakota build)
1. Log in as a sitemanager
2. Confirm you do not see links for choropleth, geojson, or geo_file visualizations under the **Visualizations** or **Add Content > Visualization** admin menu.
