### PR TITLE
Add sql-drop step before database import

### DIFF
--- a/.ahoy/site/ci.ahoy.yml
+++ b/.ahoy/site/ci.ahoy.yml
@@ -21,6 +21,8 @@ commands:
           ahoy utils files-link
         fi
         ahoy utils files-fix-permissions
+        # Drop the database to avoid any table/rows redundency.
+        ahoy drush sql-drop -y
         ahoy drush sql-cli < backups/sanitized.sql
       fi
 
@@ -30,5 +32,4 @@ commands:
       name=$(ahoy utils name)
       ahoy utils truncate-watchdog
       ahoy cmd-proxy bash hooks/common/post-code-deploy/drush-env-switch.sh $name local
-      ahoy cmd-proxy bash .ahoy/site/.scripts/deploy.sh 
-
+      ahoy cmd-proxy bash .ahoy/site/.scripts/deploy.sh


### PR DESCRIPTION
## Description
During the `ci setup` step. When a client site is detected and the associated database backup is downloaded from AWS, ahoy runs the `drush sqlc < <file_name>.sql> command. This works fine for first time setups or volatile installation (probo and circleci) but can lead to errors when the site was previously setup and the containers were not destroyed.

## QA Tests
I encountered this issue while working on USDA. Running the `ahoy site up` twice there will cause feature to panic due to the inability to create already existing tables.
