### PR TITLE
Only fail build in circle.

### DIFF
--- a/.probo.yml
+++ b/.probo.yml
@@ -52,12 +52,6 @@ steps:
       ahoy ci deploy
 
       echo ""
-      echo "-------> Diagnose and fail build if necessary"
-      echo ""
-      ahoy utils fail-when-bad-disable
-      echo ""
-
-      echo ""
       echo "The url of this build should be at:"
       echo " https://$BUILD_ID.probo.build"
       echo ""


### PR DESCRIPTION
REF See: https://jira.govdelivery.com/browse/CIVIC-5128
avoids disabling workflow in probo environments just go get build not to fail.