### PR TITLE
Make git ignore asset files folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,8 @@ Thumbs.db
 dkan/.ahoy/site/vendor/*
 dkan/.ahoy/site/vendor/composer.lock
 
+# Sanitized files #
+###################
+
+*.prod.files
+*.prod.files/*


### PR DESCRIPTION

Simple 2 liner to make new sites based off dkan_starter the asset file folder created from backups at the root of the repository