### PR TITLE
Adds placeholder for acquia_purge_https

### DIFF
--- a/config/settings.custom.php
+++ b/config/settings.custom.php
@@ -32,6 +32,10 @@ switch(ENVIRONMENT) {
     //     'nucivic_data_devops',
     //   )
     // );
+
+    // Uncomment the following line if you expect https to be clear as well
+    // in acquia's varnish
+    // conf['acquia_purge_https'] = TRUE; 
     break;
 }
 


### PR DESCRIPTION
## Description

People need to be reminded that this configuration item is need for acquia purge to clean https as well from the varnish instance.
