### PR TITLE
Remove drafty from temp_disabled_modules list.

### DIFF
--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -310,7 +310,6 @@ if (!isset($conf['features_master_temp_disabled_modules'])) {
 $conf['features_master_temp_disabled_modules'][] = 'dkan_sitewide_demo_front';
 $conf['features_master_temp_disabled_modules'][] = 'menu_token';
 $conf['features_master_temp_disabled_modules'][] = 'remote_file_source';
-$conf['features_master_temp_disabled_modules'][] = 'drafty';
 
 // Fake the 'derived_key' used to connect to Solr, if we can't find the
 // Acquia-set "AH_PRODUCTION" environment variable.


### PR DESCRIPTION
## Description

Some modules are being disabled in client sites because drafty is in the list of disabled modules when they need it, for example: LKY was getting dkan_workflow disabled because drafty is a dependency that was getting disabled.
Here I removed drafty from temp_disabled_modules list.

## QA Tests
- [x] Tests passes.
- [x] No errors on circle build.
