### PR TITLE
Fix extra spaces in `ahoy dkan uli` output

### DIFF
--- a/dkan/.ahoy/dkan.ahoy.yml
+++ b/dkan/.ahoy/dkan.ahoy.yml
@@ -187,8 +187,7 @@ commands:
   uli:
     usage: log into the
     cmd: |
-      uli=$(ahoy drush uli {{args}} | sed 's/^http.*\/default\/\(.*$\)/\1/g')
-      url="$(ahoy docker url)/$uli"
+      url=$(ahoy drush --uri="$(ahoy docker url)" uli {{args}})
       os=$(uname)
 
       if [ "$os" = "Darwin" ]; then


### PR DESCRIPTION
## Description
 `ahoy dkan uli` will generate a non working login link with extra space within the path elements.

This PR will update the way `ahoy dkan uli` generates the link by delegating the whole process to drush.

## QA
- [x] `ahoy dkan uli` is generating a working login link.
