### PR TITLE
Add registry_rebuild to CircleCi environment

### DIFF
--- a/.ahoy/site/.scripts/circle.rb
+++ b/.ahoy/site/.scripts/circle.rb
@@ -30,4 +30,4 @@ end
 
 config = YAML.load_file("config/config.yml")
 circle_ci_config = CircleCIConfig.new(config)
-puts circle_ci_config.render(template);
+File.write('circle.yml', circle_ci_config.render(template))

--- a/.ahoy/site/build.ahoy.yml
+++ b/.ahoy/site/build.ahoy.yml
@@ -153,7 +153,7 @@ commands:
     cmd: |
       # render custom .htaccess
       ahoy cmd-proxy ruby .ahoy/site/.scripts/htaccess.rb > config/.htaccess
-      ahoy cmd-proxy ruby .ahoy/site/.scripts/circle.rb > circle.yml
+      ahoy cmd-proxy ruby .ahoy/site/.scripts/circle.rb
 
       # Transpose config.yml to php
       cd .ahoy/site

--- a/assets/templates/circle.yml.erb
+++ b/assets/templates/circle.yml.erb
@@ -7,15 +7,16 @@ machine:
   environment:
     PATH: $PATH:$HOME/.config/composer/vendor/bin
     DATABASE_URL: mysql://ubuntu:@127.0.0.1:3306/circle_test
-    # Timeouts issues happen when selenium tries to spawn a new chrome 
-    # instance. I've nail that down to this selenium issue 
+    # Timeouts issues happen when selenium tries to spawn a new chrome instance.
+    # I've nail that down to this selenium issue
     # https://github.com/SeleniumHQ/docker-selenium/issues/87
     DBUS_SESSION_BUS_ADDRESS: /dev/null
 ## Customize checkout
 ## Note: Only post is supported.
 checkout:
   post:
-    # Remove the extra composer stuff that circleci loads and that is causing conflicts with drush.
+    # Remove the extra composer stuff that circleci loads and that is causing
+    # conflicts with drush.
     - rm -rf ~/.composer
 
 ## Customize dependencies
@@ -34,6 +35,7 @@ dependencies:
     - mkdir $CIRCLE_ARTIFACTS/junit
     - cd tests; composer install; cd ..
     - bash dkan/dkan-init.sh dkan --deps-only
+    - drush dl -n registry_rebuild-7.x
     - ahoy site up --db-user=ubuntu --db-pass='' --db-host=127.0.0.1 --db-port=3306 --db-name=circle_test
     - ahoy utils fail-when-bad-disable
     # Run a webserver using drush.

--- a/circle.yml
+++ b/circle.yml
@@ -7,15 +7,16 @@ machine:
   environment:
     PATH: $PATH:$HOME/.config/composer/vendor/bin
     DATABASE_URL: mysql://ubuntu:@127.0.0.1:3306/circle_test
-    # Timeouts issues happen when selenium tries to spawn a new chrome
-    # instance. I've nail that down to this selenium issue
+    # Timeouts issues happen when selenium tries to spawn a new chrome instance.
+    # I've nail that down to this selenium issue
     # https://github.com/SeleniumHQ/docker-selenium/issues/87
     DBUS_SESSION_BUS_ADDRESS: /dev/null
 ## Customize checkout
 ## Note: Only post is supported.
 checkout:
   post:
-    # Remove the extra composer stuff that circleci loads and that is causing conflicts with drush.
+    # Remove the extra composer stuff that circleci loads and that is causing
+    # conflicts with drush.
     - rm -rf ~/.composer
 
 ## Customize dependencies
@@ -34,6 +35,7 @@ dependencies:
     - mkdir $CIRCLE_ARTIFACTS/junit
     - cd tests; composer install; cd ..
     - bash dkan/dkan-init.sh dkan --deps-only
+    - drush dl -n registry_rebuild-7.x
     - ahoy site up --db-user=ubuntu --db-pass='' --db-host=127.0.0.1 --db-port=3306 --db-name=circle_test
     - ahoy utils fail-when-bad-disable
     # Run a webserver using drush.


### PR DESCRIPTION
Original ticket: CIVIC-5597

This will restore installing registry_rebuild on the CircleCi environment.

Also, this update the way we generate the `circle.yml` file to avoid having "^M" line ending characters.

## QA Tests
- [x] registry_rebuild is installed on the CircleCi Test environment and the build step (ahoy site up) is able to use it to clear the registery.
- [x] No "^M" line ending in `circleci.yml`.