### PR TITLE
Make skip_tags configurable.

### DIFF
--- a/.ahoy/site/.scripts/circle.rb
+++ b/.ahoy/site/.scripts/circle.rb
@@ -21,10 +21,23 @@ class CircleCIConfig
     else
       @memory_limit = config["circle"]["memory_limit"]
     end
+
+    default_skip_tags = [ "customizable", "fixme", "testBug"]
+    if !config["circle"] || !config["circle"]["skip_tags"]
+      @skip_tags = process_skip_tags(default_skip_tags)
+    else
+      @skip_tags = process_skip_tags(config["circle"]["skip_tags"])
+    end
   end
 
   def render(template)
     ERB.new(template).result(binding)
+  end
+
+  private
+
+  def process_skip_tags(tags)
+    tags.map {|w| "~@#{w}" }
   end
 end
 

--- a/.ahoy/site/.scripts/htaccess.rb
+++ b/.ahoy/site/.scripts/htaccess.rb
@@ -31,4 +31,4 @@ end
 
 config = YAML.load_file("config/config.yml")
 htaccess = Htaccess.new(config)
-puts htaccess.render(htaccess_template);
+File.write('config/.htaccess', htaccess.render(htaccess_template))

--- a/.ahoy/site/build.ahoy.yml
+++ b/.ahoy/site/build.ahoy.yml
@@ -152,7 +152,7 @@ commands:
     usage: ahoy build config - Applies site specific changes stored in config.yml
     cmd: |
       # render custom .htaccess
-      ahoy cmd-proxy ruby .ahoy/site/.scripts/htaccess.rb > config/.htaccess
+      ahoy cmd-proxy ruby .ahoy/site/.scripts/htaccess.rb
       ahoy cmd-proxy ruby .ahoy/site/.scripts/circle.rb
 
       # Transpose config.yml to php

--- a/assets/templates/circle.yml.erb
+++ b/assets/templates/circle.yml.erb
@@ -52,7 +52,7 @@ dependencies:
 ## Customize test commands
 test:
   override:
-    - BEHAT_FOLDER=$HOME/$CIRCLE_PROJECT_REPONAME/tests ruby dkan/.ahoy/.scripts/circle-behat.rb <%= @test_dirs.join(" ") %> --tags='~@customizable&&~@fixme&&~@testBug':
+    - BEHAT_FOLDER=$HOME/$CIRCLE_PROJECT_REPONAME/tests ruby dkan/.ahoy/.scripts/circle-behat.rb <%= @test_dirs.join(" ") %> --tags='<%= @skip_tags.join("&&") %>':
         timeout: 1200
         parallel: true
   post:

--- a/config/.htaccess
+++ b/config/.htaccess
@@ -96,14 +96,14 @@ DirectoryIndex index.php index.html index.htm
   # RewriteCond %{HTTP_HOST} !^www\. [NC]
   # RewriteCond %{HTTP_HOST} ^example\.com$ [NC]
   # RewriteRule ^ http%{ENV:protossl}://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
-
-
+ 
+  
     RewriteCond %{HTTP_HOST} ^example\.com$ [NC]
     RewriteRule ^ http%{ENV:protossl}://www.example.com%{REQUEST_URI} [L,R=301]
-
+  
     RewriteCond %{HTTP_HOST} ^oldsite\.example\.com$ [NC]
     RewriteRule ^ http%{ENV:protossl}://www.example.com%{REQUEST_URI} [L,R=301]
-
+  
 
   #
   # To redirect all users to access the site WITHOUT the 'www.' prefix,
@@ -121,8 +121,8 @@ DirectoryIndex index.php index.html index.htm
   # If your site is running in a VirtualDocumentRoot at http://example.com/,
   # uncomment the following line:
   # RewriteBase /
-
-
+  
+  
 
   # Pass all requests not referring directly to files in the filesystem to
   # index.php. Clean URLs are handled in drupal_environment_initialize().

--- a/config/config.php
+++ b/config/config.php
@@ -81,6 +81,12 @@ $conf = array (
       1 => 'dkan/test/features',
       2 => 'config/tests/features',
     ),
+    'skip_tags' => 
+    array (
+      0 => 'customizable',
+      1 => 'fixme',
+      2 => 'testBug',
+    ),
     'memory_limit' => '256M',
   ),
 );

--- a/config/config.yml
+++ b/config/config.yml
@@ -50,4 +50,8 @@ circle:
     - tests/features
     - dkan/test/features
     - config/tests/features
+  skip_tags:
+    - customizable 
+    - fixme
+    - testBug
   memory_limit: 256M


### PR DESCRIPTION
REF CIVIC-5613

Makes it possible to specific skip tags in config.yml for skipping features
tests in the circle environment.

QA Tests
===
- [x] Verify that adding entries to config.yml:circle::skip_tags and running `ahoy build config` adds configs as expected.