### PR TITLE
Fix broken search index brakes  DB pruning script.

### DIFF
--- a/.ahoy/site/.scripts/prune-database.php
+++ b/.ahoy/site/.scripts/prune-database.php
@@ -7,15 +7,17 @@
 
 include_once( dirname(__FILE__) . '/utils-prune.php');
 
+echo "Pruning nodes.";
+prune_nodes();
+
+echo "Pruning terms.";
+prune_terms();
+
+echo "Deleting Acquia search indexes.";
 db_query("DELETE FROM search_api_index where server = 'dkan_acquia_solr'");
 db_query("DELETE FROM search_api_index where server = 'local_solr_server'");
 db_query("DELETE FROM search_api_server where machine_name = 'dkan_acquia_solr';");
 db_query("DELETE FROM search_api_server where machine_name = 'local_solr_server';");
 db_query("DELETE FROM search_api_index where server IS NULL");
 
-module_load_include('inc', 'search_api', 'search_api.drush');
-drush_search_api_disable();
-
-prune_nodes();
-prune_terms();
 

--- a/.ahoy/site/utils.ahoy.yml
+++ b/.ahoy/site/utils.ahoy.yml
@@ -76,6 +76,7 @@ commands:
     usage: Prunes datasets and resources from site database
     hide: true
     cmd: |
+      ahoy drush search-api-disable --yes
       ahoy drush php-script .ahoy/site/.scripts/prune-database.php
 
   name:


### PR DESCRIPTION
REF CIVIC-5634

An indexing error thrown during the DB pruning script process causes the script
to stop midway without pruning the DB.  This changes moves disabling the index
to a higher point in the call stack in order to avoid this issue.

QA Steps
===
- [ ] Verify that the script will run without failing to prune DB nodes.