### PR TITLE
Civic 4534 - Fixed dkan starter documentation

### DIFF
--- a/docs/common_tasks/add-client-custom-config.rst
+++ b/docs/common_tasks/add-client-custom-config.rst
@@ -11,7 +11,7 @@ By custom configuration we mean:
 Whatever's you need to customise the project, you should set the feature export
 to somewhere inside the **docroot/sites/all/modules/custom** folder. That way,
 your module will **persist** when the site gets **remade** (Read Add a custom
-module if you don't understand what this means).
+module if you don't understand what this means). Please note your changes shouldn't be added directly to docroot/sites/all/modules/custom but to **config/modules/custom**, otherwise, your changes will be lost on the next DKAN Starter upgrade.
 
 However, there's a few caveats:
 

--- a/docs/common_tasks/add-contrib-library.rst
+++ b/docs/common_tasks/add-contrib-library.rst
@@ -7,7 +7,7 @@ Whenever you want to add a library you need to guarantee two specific conditions
 
 2. The module needs to be added to the project's **make file** so if the website gets rebuild (for instance when dkan get's updated), the module remains in the **codebase** and doesn't get deleted
 
-Let's say, for instance, that we want to add the [Angular](https://github.com/angular/angular) module to the project.
+Let's say, for instance, that we want to add the `Angular <https://github.com/angular/angular>`_ module to the project.
 
 Add the module to the ``custom_libs.make`` file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/common_tasks/add-contrib-module.rst
+++ b/docs/common_tasks/add-contrib-module.rst
@@ -1,7 +1,7 @@
 Add a contributed module
 ------------------------
 
-As we stated in the `Add a custom module guide <https://github.com/NuCivic/data_starter_private/blob/civic4252_make-files-public/docs/common_tasks/add-custom-module.md>`_, whenever you want to add a module (no matter if it's custom or not) you need to guarantee two specific conditions:
+Whenever you want to add a module (no matter if it's custom or not) you need to guarantee two specific conditions:
 
 1. The module needs to be added to the **codebase**
 2. The module needs to be added to the project's **make file** so if the website gets rebuild (for instance when dkan get's updated), the module remains in the **codebase** and doesn't get deleted
@@ -31,8 +31,8 @@ Add the module to the custom_config.features.features_master.inc file:
 
 .. code-block:: bash
 
-$features_master = data_config_enabled_modules();
-$features_master['modules']['sharethis'] = 'sharethis',
+  $features_master = data_config_enabled_modules();
+  $features_master['modules']['sharethis'] = 'sharethis',
 
 Remake the project
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/common_tasks/build-contrib-or-dkan-module-a-client-project.rst
+++ b/docs/common_tasks/build-contrib-or-dkan-module-a-client-project.rst
@@ -8,7 +8,7 @@ The best workflow for this is to:
 
 1. Add the module 
     
-   1. Add the module as if it was just another "contributed" module: Add a contributed module
+   1. Add the module as if it was just another "contributed" module: `Add a contributed module <../add-contrib-module.html>`_
     
    2. Once this is done a link to the module should exist in ``custom.make``.
 
@@ -36,7 +36,7 @@ The best workflow for this is to:
 Example
 ^^^^^^^
 
-Lets say you are working on a module which adds [hover-bear](http://fakeplus.com/pictures/jpg/-hover-bear_20120503062245.jpg) functionality to a client project and the module lives at http://github.com/nucivic/dkan_hover_bears.
+Lets say you are working on a module which adds `hover-bear <http://fakeplus.com/pictures/jpg/-hover-bear_20120503062245.jpg>`_ functionality to a client project and the module lives at http://github.com/nucivic/dkan_hover_bears.
 
 1. Add the module
 
@@ -61,6 +61,7 @@ Lets say you are working on a module which adds [hover-bear](http://fakeplus.com
 2. Delete the module
 
 .. code-block:: bash
+
   rm -r docroot/sites/all/modules/contrib/dkan_hover_bears
 
 3. Clone the module
@@ -71,7 +72,7 @@ Lets say you are working on a module which adds [hover-bear](http://fakeplus.com
   
 4. Commit local changes
 
-   1. cd into``docroot/sites/all/modules/contrib/dkan_hover_bears``
+   1. cd into ``docroot/sites/all/modules/contrib/dkan_hover_bears``
  
    2. commit changes
 

--- a/docs/common_tasks/change-local-container-settings.rst
+++ b/docs/common_tasks/change-local-container-settings.rst
@@ -6,4 +6,4 @@ Update php {{memory_limit}}:
 
 1. Locate the php.ini file used for the ahoy based dkan setup, usually dkan/.ahoy/.docker/etc/php5/php.ini
 2. Edit the file to set the memory_limit php variable to the needed value, for example (512M, -1 for unlimited).
-3. We need to restart the docker containers. ahoy docker stop;; ahoy docker up
+3. We need to restart the docker containers. ``ahoy docker stop;; ahoy docker up``

--- a/docs/common_tasks/enable-or-disable-a-module.rst
+++ b/docs/common_tasks/enable-or-disable-a-module.rst
@@ -1,30 +1,31 @@
 Enable or Disable a module
 --------------------------
 
-Modules are are automatically enabled or disabled every time there is an environment switch. Environment switches happen any time a database changes between Acquia instances or to Circle or locally.
+Modules are automatically enabled or disabled every time there is an environment switch. Environment switches happen any time a database changes between Acquia instances or to Circle or locally.
 
 List of Default Enabled Modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A list of modules exists in the `data_config_enabled_modules()<https://github.com/NuCivic/data_starter_private/blob/master/assets/modules/data_config/data_config.module#L6>`_ function. This is a list of modules that are always enabled. This list is periodically updated by Pluto.
+A list of modules exists in the `data_config_enabled_modules() <https://github.com/NuCivic/dkan_starter/blob/master/assets/modules/data_config/data_config.module#L6>`_ function. This is a list of modules that are always enabled. This list is periodically updated.
 
 List of Custom Enabled Modules 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A list of custom enabled modules `exists in the custom_config_features_master_defaults() <https://github.com/NuCivic/data_starter_private/blob/master/config/modules/custom/custom_config/custom_config.features.features_master.inc>`_ function in `/config/modules/custom/custom_config/custom_config.features.features_master.inc. <https://github.com/NuCivic/data_starter_private/blob/master/config/modules/custom/custom_config/custom_config.features.features_master.inc>`_
+A list of custom enabled modules exists in the `custom_config_features_master_defaults() <https://github.com/NuCivic/dkan_starter/blob/master/config/modules/custom/custom_config/custom_config.features.features_master.inc>`_ function in `/config/modules/custom/custom_config/custom_config.features.features_master.inc. <https://github.com/NuCivic/dkan_starter/blob/master/config/modules/custom/custom_config/custom_config.features.features_master.inc>`_
 
-This function takes the output of `data_config_enabled_modules() <https://github.com/NuCivic/data_starter_private/blob/master/assets/modules/data_config/data_config.module#L6>`_ and allows the final output to be overwritten.
+This function takes the output of `data_config_enabled_modules() <https://github.com/NuCivic/dkan_starter/blob/master/assets/modules/data_config/data_config.module#L6>`_ and allows the final output to be overwritten.
 
 **ANY MODULE NOT INCLUDED IN THE $features_master ARRAY WILL BE DISABLED ON PRODUCTION.**
 
 Enabling or Disabling a Module on Production
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-While modules can be manually enabled they will be turned off anytime new code is deployed. 
+While modules can be manually enabled, they will be turned off anytime new code is deployed. 
 
-To add a module to the enabled modules list, add the module to the $features_master list in the `custom_config_features_master_defaults() <https://github.com/NuCivic/data_starter_private/blob/master/config/modules/custom/custom_config/custom_config.features.features_master.inc>`_ function:
+To add a module to the enabled modules list, add the module to the $features_master list in the `custom_config_features_master_defaults() <https://github.com/NuCivic/dkan_starter/blob/master/config/modules/custom/custom_config/custom_config.features.features_master.inc>`_ function:
 
 .. code-block:: php
+
  <?php
  function custom_config_features_master_defaults() {
 

--- a/docs/common_tasks/getting-content-into-a-probo-site.md
+++ b/docs/common_tasks/getting-content-into-a-probo-site.md
@@ -7,4 +7,4 @@ When you want to have a specific content on a Probo Site.
 The easiest way to get content into a Probo Site is to add it to the production site:
 
 1. Add the content you want to the production site.
-2. Run the Backup DB to S3 Jenkins Job for the site: 
+2. Run the Backup DB to S3 Jenkins Job for the site.

--- a/docs/common_tasks/override-and-upstream-behat-suite-config.md
+++ b/docs/common_tasks/override-and-upstream-behat-suite-config.md
@@ -4,7 +4,7 @@ Sometimes site developers may have a need to override an upstream suite configur
 
 ### Step-by-step guide
 
-1. open up config/tests/behat.custom.yml
+1. Open up ``config/tests/behat.custom.yml``
 2. If an entry for the suite you want to override is not present, then add it
 3. Add filters filters or override what contexts or where contexts being loaded from.  The example below shows us adding a name: filter to the dkan suite.
 

--- a/docs/common_tasks/patching-or-overriding-dkan.rst
+++ b/docs/common_tasks/patching-or-overriding-dkan.rst
@@ -27,7 +27,7 @@ Overrides are applied in the build process when running
 
   ahoy build update VERSION 
   
-See Updating Data Starter to Latest Version of DKAN
+See `Updating DKAN Starter to Latest Version of DKAN <update-to-latest-dkan.html>`_
 
 Here is a step by step process:
 

--- a/docs/common_tasks/setting-up-local-project.rst
+++ b/docs/common_tasks/setting-up-local-project.rst
@@ -1,7 +1,7 @@
 Setting up a project locally
 ----------------------------
 
-1. Install docker as described in :doc:`../getting_started/setting-up-local-docker`
+1. Install docker as described in `this guide <../docker-dev-env/installation.html>`_
 2. Run 
 
 .. code-block:: bash
@@ -72,4 +72,4 @@ of course the specific module will depend on your error.
 Hostname/alias errors
 ~~~~~~~~~~~~~~~~~~~~~
 
-The ahoy custom setup command will fail if you do not have the Acquia aliases set up correctly on your local environment. Make sure you are logged into Acquia (drush ac-api-login) then update your Acquia aliases (drush acquia-update).
+The `ahoy ci setup` command will fail if you do not have the Acquia aliases set up correctly on your local environment. Make sure you are logged into Acquia (drush ac-api-login) then update your Acquia aliases (drush acquia-update).

--- a/docs/common_tasks/update-config.yml-settings.rst
+++ b/docs/common_tasks/update-config.yml-settings.rst
@@ -7,4 +7,4 @@ To run updates from config.yml run:
 
 .. code-block:: bash
 
-  ahoy build custom
+  ahoy build config

--- a/docs/common_tasks/update-data-starter.rst
+++ b/docs/common_tasks/update-data-starter.rst
@@ -1,5 +1,5 @@
 Update DKAN Starter
-------------------
+-------------------
 
 There is a new command 
 
@@ -11,11 +11,11 @@ There is a new command
 
 This performs the following:
 
-* **ahoy data-starter-update VERSION**  downloads data_starter_private and updates everything outside of the 'config' folder.
+* **ahoy build update-dkan-starter VERSION**  downloads dkan_starter and updates everything outside of the 'config' folder.
 * **ahoy build custom updates** the custom modules in custom.make
 * **ahoy build overrides** patches dkan with items from overrides.make
 * **ahoy build config** adds config in config.yml to various items
 
-This removes everything outside of the config/ folder with the data_starter updates and then applies the local overrides and settings that are contained in the config folder.
+This removes everything outside of the config/ folder with the dkan_starter updates and then applies the local overrides and settings that are contained in the config folder.
 
 If a module is removed from sites/all/modules/contrib after running ``ahoy build update VERSION`` then it was not defined in ``custom.make``.

--- a/docs/common_tasks/update-to-latest-dkan.rst
+++ b/docs/common_tasks/update-to-latest-dkan.rst
@@ -8,9 +8,10 @@ To upgrade to the latest available version of DKAN, run:
 
 .. code-block:: bash
 
-  ahoy build update DATA-STARTER-VERSION
+  ahoy build update DKAN-STARTER-VERSION
 
 This command: 
-* updates everything in the repo except the config/ folder from data_starter
+
+* updates everything in the repo except the config/ folder from dkan_starter
 * runs custom.make and overrides.make
 * runs config.yml customizations

--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -17,6 +17,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
 Please review the following pieces of Documentation if you haven't done so yet:
+
 * :doc:`../modules/features-master`
 * :doc:`../modules/custom-config`
 * :doc:`../modules/data-config`
@@ -34,12 +35,13 @@ Those predefined conditions are:
 * There are complementary modules that could be enabled (for specific or all environments) setting up values for the **features_master_temp_enabled_modules** variable in settings.php file.
 * There are complementary modules that could be disabled (for specific or all environments) setting up values for the **features_master_temp_disabled_modules** variable in settings.php file.
 * Any enabled module that's not cover by the above three statements will be disabled.
-* There are configuration items (variables) set up (for specific or all) environments.
+* There are configuration items (variables) set up for specific (or all) environments.
 
 Hooks
 ^^^^^
 
-For NuCivic Data Projects we are implementing deployment hooks for:
+For Granicus Data Projects we are implementing deployment hooks for:
+
 * **post-code-deploy**: This runs when code is deployed from one environment from another (i.e elevating code from dev to test, test to prod)
 * **post-code-update**: This runs when code is push to the acquia's master branch. This only runs if the dev environment is running the master branch
 * **post-db-copy**: This runs when a database is deployed from on environment to another (i.e moving prod db to test and dev)
@@ -76,7 +78,7 @@ The command that actually does it all is:
 
    drush @$drush_alias env-switch $target_env --force
 
-Let's examine what happends when the environment switching occur following data_starter settings.php file.
+Let's examine what happens when the environment switching occur following dkan_starter settings.php file.
 
 1. Drupal is bootstrapped
 
@@ -94,7 +96,7 @@ Let's examine what happends when the environment switching occur following data_
       );
       devinci_set_env($env_map);
    
-   2. A set of global (not environment specific) configuration is set bellow the environment mapping. Things like error reporting, the default mail_system, default caching options, zip compression, fast_404, and many settings more.
+   2. A set of global (not environment specific) configuration is set below the environment mapping. Things like error reporting, the default mail_system, default caching options, zip compression, fast_404, and many settings more.
 
    3. Environment specific happens after b) enclosed in a switch statement that analyses the ``ENVIRONMENT`` constant:
 
@@ -142,11 +144,11 @@ Let's examine what happends when the environment switching occur following data_
    * **Local** and **Dev** are treated as development environments, so we turn on development modules on those.
    * **Test** mimics the Prod environment in everything BUT email backend configuration. We simply don't want Test to send emails.
    * **Test** and **Prod** are treated as production environments, which means performance is key. We set up caching and do things like adding memcache (if available).
-   * **Dev**, **Tes*t**, and **Prod** are set to turn on every acquia module we need to make use of search and performance tuning.
+   * **Dev**, **Test**, and **Prod** are set to turn on every acquia module we need to make use of search and performance tuning.
 
 2. Env switching happens
 
-   The definition for what happens on environment switching lives in devinci_custom_environment_switch implementation of hook_custom_environment_switch. For data_starter we add it at the bottom of settings.php and it looks like something like this:
+   The definition for what happens on environment switching lives in devinci_custom_environment_switch implementation of hook_custom_environment_switch. For dkan_starter we add it at the bottom of settings.php and it looks like something like this:
 
    .. code-block:: php
 

--- a/docs/docker-dev-env/ahoy.md
+++ b/docs/docker-dev-env/ahoy.md
@@ -25,7 +25,7 @@ DKAN's ahoy commands are stored in the ``.ahoy/`` folder in DKAN.
 
 ## DKAN Starter and Ahoy
 
-DKAN Starter ahoy commands are stored in the ``.ahoy/sites/`` folder in DKAN.
+DKAN Starter ahoy commands are stored in the ``.ahoy/sites/`` folder in DKAN Starter.
 
 # TODO: enable ahoy v2
 Everything below this line is currently not yet available.

--- a/docs/docker-dev-env/docker-changes.rst
+++ b/docs/docker-dev-env/docker-changes.rst
@@ -1,4 +1,4 @@
-This details how to update the docker images for DKAN. NuCivic owns the containers but the same steps can be made to create your own images. We will also accept timely PRs with an updated container.
+This details how to update the docker images for DKAN. Granicus owns the containers but the same steps can be made to create your own images. We will also accept timely PRs with an updated container.
 
 Step-by-step guide
 -----------------

--- a/docs/docker-dev-env/installation.rst
+++ b/docs/docker-dev-env/installation.rst
@@ -5,13 +5,13 @@ The steps to setup the DKAN development environment are as following:
 
 1. Run the universal Docker installer (recommended) and/or run the commands manually to make sure that the Docker Machine is properly setup.
 2. Make sure the Docker Machine is started
-3. Clone DKAN, install it in Docker Machine and start developing. Clone a Data_starter project, install it in Docker Machine and start developing.
+3. Clone DKAN, install it in Docker Machine and start developing. Or clone a dkan_starter project, install it in Docker Machine and start developing.
 4. Universal Docker Installer
 
 1. Universal Docker Installer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The universal Docker installer is available in the `Universal Installer <https://github.com/NuCivic/universal-docker-installer>`_ repository 
+The universal Docker installer is available in the `Universal Installer <https://github.com/NuCivic/universal-docker-installer>`_ repository.
 Check the Readme on the Github repository to setup the docker development environment.
 
 1.1 Setup the installer dependencies
@@ -32,49 +32,56 @@ Check the Readme on the Github repository to setup the docker development enviro
 2. Docker machine
 ^^^^^^^^^^^^^^^^^
 
-Before starting to work on DKAN sites the developer needs to make sure that the development docker machine is up and running as following: 
+Before starting to work on DKAN sites, the developer needs to make sure that the development docker machine is up and running as following: 
 
 .. code-block:: bash
 
   docker-machine status default
   docker-machine start default
 
-When The developer is done developing DKAN, the docker machine could be checked and stopped as following:
+When the developer is done developing DKAN, the docker machine could be checked and stopped as following:
 
 .. code-block:: bash
+
   docker-machine status default
   docker-machine stop default
-  
+
 To manage the default Virtualbox machine (the docker machine), a developer can use the following commands:
 
 1. Check the machine status: 
 
 .. code-block:: bash
+
   docker-machine status default
 
 2. List the existing docker machines: 
 
 .. code-block:: bash
+
   docker-machine ls
 
 3. Start the default machine: 
 
 .. code-block:: bash
+
   docker-machine start default
 
 4. Stop the default machine
 
 .. code-block:: bash
+
   docker-machine stop default
 
 5. Check the default machine IP address
 
 .. code-block:: bash
+
   docker-machine ip default
 
 6. SSH into the default machine:
 
 .. code-block:: bash
+
   docker-machine ssh default
 
 For a detailed docker-machine command line reference check the following link: `https://docs.docker.com/machine/reference/ <https://docs.docker.com/machine/reference/>`_
@@ -85,6 +92,7 @@ For a detailed docker-machine command line reference check the following link: `
 To get started with DKAN development you need to follow these steps:
 
 .. code-block:: bash
+
   cd ~/docker
   git clone git@github.com:NuCivic/dkan.git
   cd dkan
@@ -106,9 +114,10 @@ In the dkan folder you can see the following directories:
 3. ``backups/``: Contains SQL backup/dump file (last_install.sql) for the last DKAN site reinstall.
 
 Make changes to dkan, add, commit and push.
-When done developing for this project execute the following command: ahoy docker stop
-When done developing with Docker Machine for any DKAN related project execute the following command: docker-machine stop default
+When done developing for this project execute the following command: ``ahoy docker stop``
+When done developing with Docker Machine for any DKAN related project execute the following command: ``docker-machine stop default``
 
 4. Getting started with DKAN Starter development
-^^^^^^^^^^^^^^^^^
-See: [Setting up a project locally](../common_tasks/setting-up-local-project)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See: `Setting up a project locally <../common_tasks/setting-up-local-project>`_

--- a/docs/getting_started/creating-a-new-project.md
+++ b/docs/getting_started/creating-a-new-project.md
@@ -56,7 +56,7 @@ We will share the actual jobs for this soon.
 
 At the least you need a mechanism for providing pruned and sanitized backups for your site to S3 or another mechanism to do so.
 
-You can simply setup the ``ahoy utils asset-download-db`` job to download directly from your production instance for local development, ProboCI, and CirlceCI however we recommend using a pruned and sanitized version of your database for these services.
+You can simply setup the ``ahoy utils asset-download-db`` job to download directly from your production instance for local development, ProboCI, and CirlceCI; however, we recommend using a pruned and sanitized version of your database for these services.
 
 ## Custom Site Configuration
 

--- a/docs/getting_started/custom-site-configuration.md
+++ b/docs/getting_started/custom-site-configuration.md
@@ -25,6 +25,8 @@ default:
   https_securepages: FALSE              [Whether to use securepages module for mixed https. Not recommended.]
   clamav:     
     enable: FALSE                       [Whether to enable clamav module. Requires clamav support from host.]
+  dkan_workflow:
+    enable: FALSE                       [Whether to enable dkan_workflow.module.]
   stage_file_proxy_origin: changeme     [Whether to use state file proxy module for files. Recommended as set to staging or production environment.]
   fast_file:      
     enable: TRUE                        [Whether to use DKAN's fast file import for the Datastore.]
@@ -35,12 +37,23 @@ private:
     scrubbed_data_url: CHANGE ME        [Private S3 bucket for backups.]
   probo:
     password: CHANGE ME                 [Password for user 1 on ProboCI sites. This is changed from production for security reasons.]
+gaClientTrackingCode: UA-XXXXX-Y        [Google Analytics tracking code for the site.]
+circle:
+  test_dirs:                            [List of directories with features tests that needs to be run on CircleCI. Default to tests/features, dkan/tests/features and config/tests/features.]
+    - tests/features
+    - dkan/test/features
+    - config/tests/features
+  skip_tags:                            [List of tags that will be skipped when running tests. Defaults to customizable, fixme and testBug.]
+    - customizable
+    - fixme
+    - testBug
+  memory_limit: 256M                    [Memory limit for CircleCI.]
 ```
 ## Deciding Which Modules are Enabled
 
 Only modules that are part of the list at ``assets/modules/data_config/data_config.module:data_config_enabled_modules()`` or added to ``config/modules/custom/custom_config/custom_config.features.features_master.inc:custom_config_features_master_defaults()`` will be enabled any time you switch environments.
 
-If you want to add modules add them to the list here in the ``custom_config_features_master_defaults()`` function.
+If you want to add modules, add them to the list here in the ``custom_config_features_master_defaults()`` function.
 
 There are also modules that are enabled or disabled on certain environments. These are defined in ``assets/sites/default/settings.php`` in the
 
@@ -61,7 +74,7 @@ $conf['features_master_temp_enabled_modules'] = array(
 );
 ```
 
-We've added the ``features_master_temp_enabled_modules`` feature so that some modules can be turned on locally or on test environments. The ``maillog`` module keeps emails from being sent to clients or users.
+We've added the ``features_master_temp_enabled_modules`` feature so that some modules can be turned on locally or on test environments. The ``maillog`` module keeps emails from being sent to clients or users. Anyways, remember that if you want to add a new module to that list, you should be doing it in settings.custom.php.
 
 ## Adding Custom and Contributed Modules, Libraries and Themes
 

--- a/docs/getting_started/project-plan.md
+++ b/docs/getting_started/project-plan.md
@@ -4,7 +4,7 @@ Before you [Create a new project](creating-a-new-project.md) read the following 
 
 There are many reasons why teams can't use the tools below and we have worked with many of them that have had successful workflows and deployments.
 
-## Determine Which Tools You Can User
+## Determine Which Tools You Can Use
 
 DKAN Starter is optimized to work with the following:
 
@@ -56,7 +56,7 @@ If you are unable to use Jenkins it is recommended to use a similar task runner.
 If you are unable to use Amazon's S3 for backups you need to setup a place to keep backups that is secure and developers and CI tools can access.
 
 ### Acquia
-If you are unable to use Acquia there many hosts that can be substituted or a bespoke hosting platform can be setup however it needs to have the following characteristics:
+If you are unable to use Acquia there are many hosts that can be substituted or a bespoke hosting platform can be setup, however, it needs to have the following characteristics:
 
 * Git integration
 * Drush alias support
@@ -72,6 +72,6 @@ If you are unable to use Acquia there many hosts that can be substituted or a be
 
 You can use [this checklist](https://docs.google.com/spreadsheets/d/167rJVtwfg5S5kBdsbr34i27nDR3-u8Ligh4lypobips/edit#gid=0) as a tool for preparing your Project Plan. Make a copy for your own project.
 
-## Contact GovDelivery
+## Contact Granicus
 
-We would love to hear from you if you are using DKAN Starter. Contact us through the DKAN channels: https://github.com/NuCivic/dkan#getting-help-with-dkan or email us at ``aaron.couch (at) govdelivery.com``. Let us know your use case, questions or concerns.
+We would love to hear from you if you are using DKAN Starter. Contact us through the [DKAN channels](https://getdkan.com/community). Let us know your use case, questions or concerns.

--- a/docs/introduction/dkan-starter-annotated.rst
+++ b/docs/introduction/dkan-starter-annotated.rst
@@ -8,6 +8,7 @@ DKAN Starter Structure
 The following is the root structure for DKAN Starter:
 
 .. code-block:: bash
+
   .ahoy/                       [Ahoy files. See note below.]
   CHANGELOG.md                 [Changelog for DKAN Starter. All releases include an entry.]
   README.md                    [Description of DKAN Starter.]
@@ -26,7 +27,7 @@ The following is the root structure for DKAN Starter:
 
 
 ``docroot/``
-~~~~~~~~~~~
+~~~~~~~~~~~~
 
 This is the docroot that the webserver on your environments will point to. The docroot is never edited directly and is always rebuilt from a combination of sources. Everything except for:
 
@@ -39,7 +40,7 @@ come from the upstream version of DKAN Starter.
 The docroot is rebuilt by running *ahoy build update* command.
 
 ``.ahoy/``
-~~~~~~~~~
+~~~~~~~~~~
 
 This contains our ahoy scripts. All parts of the DKAN Starter workflow run through the ahoy commands.
 
@@ -51,11 +52,12 @@ This folder includes DKAN Starter modules, patches, and other miscellaneous asse
 ``config/``
 ~~~~~~~~~~~
 
-In in effort to simplify how we configure and customize projects we have  added `./config` to capture all configurations an customizations to a data_starter project.
+In an effort to simplify how we configure and customize projects we have  added `./config` to capture all configurations and customizations to a dkan_starter project.
 The idea with this folder is to capture all customizations across our sites in one place  as well as to separate the logic that uses custom configuration from the configuration itself.
 The current structure of the config folder is:
 
 .. code-block:: bash
+
   config/
     aliases.local.php
     config.php
@@ -81,7 +83,7 @@ The new files that have not been seen in previous setups are the config.yml, con
 config.php
 ~~~~~~~~~~~
 
-You should forget about.  This file is created automatically by running `ahoy build config` and it is derived in part by what you add to `./config/config.yml`.
+You should forget about it.  This file is created automatically by running `ahoy build config` and it is derived in part by what you add to `./config/config.yml`.
 
 config.yml
 ~~~~~~~~~~~
@@ -91,7 +93,7 @@ This is where we will now keep all of the site specific configurations.  This fi
 settings.custom.php
 ~~~~~~~~~~~~~~~~~~~
 
-This is where settings.php logic that is custom to a site will live, so that it will be much easier to see how, if at all, a site's settings logic is different from another.  Currently we use the devinci along with the environment module to automatically run changes between environments.  Often there are site specific difference that happen between the different installations.  This is where we can capture these logic difference.  Note, that we may move away from how we run deployments (a la devinci style) so this file may become unnecessary.
+This is where settings.php logic that is custom to a site will live, so that it will be much easier to see how, if at all, a site's settings logic is different from another.  Currently we use the devinci along with the environment module to automatically run changes between environments.  Often there are site specific differences that happen between the different installations.  This is where we can capture these logic difference.  Note, that we may move away from how we run deployments (a la devinci style) so this file may become unnecessary.
 
 custom.make
 ~~~~~~~~~~~
@@ -114,16 +116,16 @@ custom_libs.make
 3rd-party libraries are added to this make file.
 
 ``modules/custom/``
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 Custom modules built for this project are added here. Any modules added to this folder are added to ``docroot/sites/all/modules/custom`` through a symlink.
 
 ``modules/custom/custom_config/``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This module is for custom configuration of DKAN. Implementers can use this module or another custom module for customizations.
 
 custom_config.features.features_master.inc
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``modules/custom/custom_config/custom_config.features.features_master.inc`` file contains a list of the modules that you want enabled on your site.

--- a/docs/introduction/dkan-starter-overview.md
+++ b/docs/introduction/dkan-starter-overview.md
@@ -44,4 +44,4 @@ Without proper management updating a Drupal or DKAN site quickly can be very dif
 
 Config/
 -------
-All of the development for DKAN Starter implementers is done in the ``config/`` folder. Everything outside of the ``config/`` folder will be overwritten after every update. GovDelivery provides updates to DKAN Starter immediately after DKAN patch or minor releases or after an update to DKAN Starter. Implementers can simply run the command ``ahoy build update DKAN-STARTER-VERSION`` to get the latest version of DKAN and DKAN Starter.
+All of the development for DKAN Starter implementers is done in the ``config/`` folder. Everything outside of the ``config/`` folder will be overwritten after every update. Granicus provides updates to DKAN Starter immediately after DKAN patch or minor releases or after an update to DKAN Starter. Implementers can simply run the command ``ahoy build update DKAN-STARTER-VERSION`` to get the latest version of DKAN and DKAN Starter.

--- a/docs/introduction/getting-help.rst
+++ b/docs/introduction/getting-help.rst
@@ -1,4 +1,4 @@
 Getting Help
-==========
+============
 
 Please file tickets if you have any questions or issues in the `DKAN repository <https://github.com/NuCivic/dkan/issues>`_ . We will respond as soon as possible.

--- a/docs/introduction/releases.md
+++ b/docs/introduction/releases.md
@@ -1,7 +1,7 @@
 Releases
 ==========
 
-Releases for DKAN Starter are posted on the Github release page:  https://github.com/NuCivic/dkan_starter/releases)
+Releases for DKAN Starter are posted on the [Github release page](https://github.com/NuCivic/dkan_starter/releases)
 
 Please read DKAN Starter changelog for keeping up to date as well as the release notes.
 
@@ -18,9 +18,9 @@ So if we've got:
 
 That means:
 * *1.12.2* -> dkan's patch release dkan_starter is running
-* *.4* -> we've released 4 incremental updates over dkan_starter since we've rebuild data_starter using 1.12.2
+* *.4* -> we've released 4 incremental updates over dkan_starter since we've rebuild dkan_starter using 1.12.2
 
-Every time we rebuild data_starter using a new version we'll reset the counter to 0. So:
+Every time we rebuild dkan_starter using a new version we'll reset the counter to 0. So:
 * 1.13.0
 
-Means we just rebuilt data_starter with the ``7.x-1.13`` tag.
+Means we just rebuilt dkan_starter with the ``7.x-1.13`` tag.

--- a/docs/modules/devinci.rst
+++ b/docs/modules/devinci.rst
@@ -12,7 +12,7 @@ This would, out of the box, set an ENVIRONMENT constant and do a number of reall
 
  * ENVIRONMENT is already set as a drupal constant
  * ENVIRONMENT is defined as a linux environment variable
- * the current instance is an acquia instance and adding the required require "/var/www/site-php/$sitegroup/$sitegroup-settings.inc"; setting file with the proper credentials for your subscription (Pantheon is on the roadmap)
+ * the current instance is an acquia instance and adding the required ``require "/var/www/site-php/$sitegroup/$sitegroup-settings.inc";`` setting file with the proper credentials for your subscription (Pantheon is on the roadmap)
  * there's a custom environment.settings.php file at DRUPAL_ROOT . '/' . conf_path() to be included.
 
 By default, DEVINCI extends the base environment module definitions (development and production) and adds the local and test environments to the mix.

--- a/docs/modules/environment.rst
+++ b/docs/modules/environment.rst
@@ -48,10 +48,10 @@ it will enable all the module defined in the $devel_modules variable. On the oth
 
     drush env-switch production
 
-The opposite will happen (all the devel modules will be disable). This is of course a very simple implementation of what you can achieve with this module.
+The opposite will happen (all the devel modules will be disabled). This is of course a very simple implementation of what you can achieve with this module.
 
 For DKAN Starter we are making heavy use of the environment module to allow stuff to happen when we deploy code and copy databases through environments. If you want to fully grasp how we are doing this you need to read the following pieces of documentation:
 
  * :doc:`custom-config`
  * :doc:`devinci`
- * Hands free deployments
+ * `Hands free deployments <../deployment/index.html#concept-behind-hands-free-deployments>`_

--- a/docs/modules/features-override.rst
+++ b/docs/modules/features-override.rst
@@ -12,6 +12,6 @@ It is very important to understand that features overrides should be the very la
  1. Find a hook alter implementation that lets you modify the configuration item you need to override.
  2. If you don't find a hook alter implementation, look again for it.
  3. Don't expect google or drupalstackexchange to give you the answer, take a look at the code for the module that implements whatever you are trying to override
- 4. If you need to set different values for a variable depending on the environment, do it in the drupal settings.php file. There's plenty of examples on how to achieve this in https://github.com/NuCivic/data_starter/blob/master/assets/sites/default/settings.php#L98
+ 4. If you need to set different values for a variable depending on the environment, do it in the drupal settings.php file. There's plenty of examples on how to achieve this in https://github.com/NuCivic/dkan_starter/blob/master/assets/sites/default/settings.php#L165
  5. Take a look on why the item you are trying to override is exported as a feature in the first place and, if possible, propose a way to take it off features and implement a hook alter implementation so devs can tweak it to their liking.
  6. If none of the above works for you, then go with features_overrides. But really, why are even you doing this to yourself?


### PR DESCRIPTION
## Description
- Changed every appearance of NuCivic or GovDelivery for Granicus.
- Changed every appearance of data_starter or data_starter_private for dkan_starter
- Fixed typos, added punctuation signs.
- Added explanation for settings from config/config.yml 
- Fixed rst syntax (and standards).
- Fixed links syntax/format on md and rst files.
- Fixed broken links.
- Removed appearance of "Pluto".
- Changed `ahoy custom setup` here: http://dkan-starter.readthedocs.io/en/latest/common_tasks/setting-up-local-project.html#hostname-alias-errors to `ahoy ci setup`
- Changed `ahoy build custom` to `ahoy build config` here http://dkan-starter.readthedocs.io/en/latest/common_tasks/update-config.yml-settings.html because `ahoy build custom` downloads 3rd party projects, the one which collects the settings is `ahoy build config`.

## QA Tests
- Someone should build the docs locally and take a look at how it looks.
