### PR TITLE
[CIVIC-5730] Fix backup database reuse

### DIFF
--- a/.ahoy/site/ci.ahoy.yml
+++ b/.ahoy/site/ci.ahoy.yml
@@ -21,8 +21,8 @@ commands:
           ahoy utils files-link
         fi
         ahoy utils files-fix-permissions
-        # Drop the database to avoid any table/rows redundency.
-        ahoy drush sql-drop -y
+
+        # Old database should've been cleaned in the ahoy site reinstall step.
         ahoy drush sql-cli < backups/sanitized.sql
       fi
 

--- a/dkan/.ahoy/dkan.ahoy.yml
+++ b/dkan/.ahoy/dkan.ahoy.yml
@@ -44,8 +44,13 @@ commands:
       if [ ! -d backups ]; then
         mkdir backups
       fi
+
+      # Drop the database to avoid any table/rows redundency.
+      # the sql-drop have the habit of quitting with error. Disable the shell
+      # error fail option just for this time.
+      set +e; ahoy drush sql-drop -y; set -e
+
       if [ -f backups/last_install.sql ] && ahoy confirm "An existing installation backup exists at backups/last_install.sql, do you want to use that instead of reinstalling from scratch?"; then
-        ahoy drush sql-drop -y && \
         ahoy dkan sqlc <  backups/last_install.sql && \
         echo "Installed dkan from backup"
       else


### PR DESCRIPTION
## Description
**Issue**: CIVIC-5730

To avoid data duplication we introduced a setup to drop the database before installing the dkan site. Unfortunately this broke the code that supported using a backup database instead of re-installing from scratch.

This PR will make database cleaning more friendly toward backup database reuse.

## QA Tests
- [ ] Using the database backup reuse should be working on `ahoy site up`.