### PR TITLE
Add a tag @defaultHomepage to make a topic test skippable.

### DIFF
--- a/dkan/test/features/topics.feature
+++ b/dkan/test/features/topics.feature
@@ -13,7 +13,7 @@ Feature: Topics
       | name         | url                                        |
       | Add Topic    | /admin/structure/taxonomy/dkan_topics/add  |
 
-  @api @Topics
+  @api @Topics @defaultHomepage
   Scenario: See topics on the homepage as anonymous user
     When I am on the homepage
     Then I should see "Topic1"


### PR DESCRIPTION
## Description
Client sites that don't have the Featured Topics block in the homepage have this test failing: https://github.com/NuCivic/dkan/blob/7.x-1.x/test/features/topics.feature#L17

This is a temporary fix, the actual fix is happening in https://github.com/NuCivic/dkan/pull/1728 but we decided to do it here because it is needed, it can be a blocker for tests passing in some client sites and we can't wait too long until a new dkan patch release is out.

## QA Tests
- [ ] The scenario: See topics on the homepage as anonymous user from topics.feature line 17 has a tag @defaultHomepage which allows it to be skipped via config.yml in client sites.
