### PR TITLE
Check if docroot/sites/all/libraries directory exists before executing drush make for custom libs.

### DIFF
--- a/.ahoy/site/build.ahoy.yml
+++ b/.ahoy/site/build.ahoy.yml
@@ -76,6 +76,11 @@ commands:
   custom-libs:
     usage: Downloads 3rd party libraries
     cmd: |
+      if [ ! -d docroot/sites/all/libraries ]; then
+         echo 'Creating docroot/sites/all/libraries'
+         mkdir docroot/sites/all/libraries
+      fi
+
       # Make writable so that error not thrown on second attempt.
       mkdir -p contrib/libraries && chmod 777 contrib/libraries
 


### PR DESCRIPTION
Jira reference: CIVIC-5815.

## Description
There is an issue when building client sites which has custom libraries, some of the libraries inside docroot/sites/all/libraries are not correctly placed, for example, depending on the environment sometimes we get all the contents for php-shellcommand outside the directory php-shellcommand, sometimes it happens for react and some other times it happens for d3, or any other library they could have.

This is happening because the command `ahoy build custom-libs` is not working as expected when the directory docroot/sites/all/libraries doesn't exist, so we need to add a step in that command to check for its existence and if it isn't there, create it.

## QA Tests
- [x] The command `ahoy build custom-libs` has a step for checking if docroot/sites/all/libraries and creating it if it doesn't exists.
- [x] The command `ahoy build update VERSION` works correctly without doing anything else.
- [x] When `ahoy build update VERSION` is run on a client site, all its custom libraries are placed in the right place when running the update command.
