### PR TITLE
Update workflow config to mach data_config

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -16,7 +16,7 @@ $conf = array (
     ),
     'dkan_workflow' => 
     array (
-      'enabled' => false,
+      'enable' => false,
     ),
     'stage_file_proxy_origin' => 'changeme',
     'fast_file' => 

--- a/config/config.yml
+++ b/config/config.yml
@@ -5,7 +5,7 @@ default:
   clamav:
     enable: FALSE
   dkan_workflow:
-    enabled: FALSE
+    enable: FALSE
   stage_file_proxy_origin: changeme
   fast_file:
     enable: TRUE


### PR DESCRIPTION
## Description
There is a miss-match between the variable `data_config` is expecting to check for dkan_workflow status and the one defined in `config.yml`

## QA Tests
- [x] Setting the `dkan_workflow` `enable` flag to TRUE should make `dkan_workflow` and dependencies modules part of the features master lists.
