### PR TITLE
Fixed call of homepage conversion function on upgrade script

### DIFF
--- a/.ahoy/site/.scripts/upgrades/upgrade_1_13.sh
+++ b/.ahoy/site/.scripts/upgrades/upgrade_1_13.sh
@@ -23,11 +23,7 @@ drush @$drush_alias en dkan_ipe -y
 drush @$drush_alias en dkan_harvest_dashboard -y
 drush @$drush_alias en menu_admin_per_menu -y
 
-page_status=`drush @drush_alias php-eval "dkan_sitewide_page_is_frontpage('front_page');"`
-
-if [ "$page_status" = "FALSE" ]; then
-  drush @$drush_alias php-eval "dkan_sitewide_convert_panel_page('front_page');"
-fi
+drush @$drush_alias php-eval "dkan_sitewide_convert_panel_page('front_page', TRUE);"
 
 drush @$drush_alias fra -y
 drush @$drush_alias rr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add example.config.yml on update. #103
 - Fix `ahoy drush custom-libs` #102
 - Fix backup database reuse #98
+- Fixed homepage conversion call on upgrade script #100
 
 ## [1.13.0.0]
 - Remake with dkan 7.x-1.13 #96


### PR DESCRIPTION
## Description

- The line that was used to check if a page was the homepage was removed because it's not needed.
- A "TRUE" parameter was added on the homepage conversion function call in order to specify that the page that is being converted is a homepage.

## QA Tests

- [ ] This needs to be tested on a client site. Choose CA for example.
- [ ] Clone client site.
- [ ] Run 'ahoy docker up'
- [ ] Run 'ahoy build update 5799_fix_homepage_conversion'
- [ ] Run 'ahoy site up'
- [ ] Confirm that:

1)  The homepage was converted automatically from panel page to node page.
2) The panel page remains available on the 'Pages' section but disabled.
3) The new node page was set as the homepage. 
