### PR TITLE
Fix pass NULL in data_config_enabled_modules().

### DIFF
--- a/assets/modules/data_config/data_config.module
+++ b/assets/modules/data_config/data_config.module
@@ -269,8 +269,9 @@ function data_config_modules_disabled($modules) {
         }
         $dependencies[$module] = array_intersect($dependencies[$module], $modules_warn);
       }
-      module_load_include('inc','custom_config','features.features_master');
-      $feature_master_list = function_exists('custom_config_features_master_defaults') ? custom_config_features_master_defaults(): array();
+      module_load_include('inc','custom_config','custom_config.features.features_master');
+      $feature_master_list = function_exists('custom_config_features_master_defaults') ?
+        custom_config_features_master_defaults(): array('modules' => array());
       $feature_master_list = array_keys($feature_master_list['modules']);
       $dpt_output = array(
         array('Modules being disabled', 'In feature master list?', 'Cross Dependencies with modules being disabled'),


### PR DESCRIPTION
data_config_enabled_modules() is failing to load proper file source file and
also trying to pass NULL internally causing errors.

The following errors get thrown during deployment:
```
D custom_config_disable: Trying to disable module(s) not on temporarily disabled list                                                                               [error]
array_keys() expects parameter 1 to be array, null given data_config.module:274                                                                                      [warning]
in_array() expects parameter 2 to be array, null given data_config.module:279     
```


QA Steps
===
- [x] The errors above go away.