### PR TITLE
Do not disable dkan_sitewide_demo_front via script.

### DIFF
--- a/.ahoy/site/.scripts/upgrades/upgrade_1_13.sh
+++ b/.ahoy/site/.scripts/upgrades/upgrade_1_13.sh
@@ -3,7 +3,7 @@
 
 drush @$drush_alias rr
 
-drush @$drush_alias dis -y dkan_sitewide_demo_front menu_token remote_file_source rdf
+drush @$drush_alias dis -y menu_token remote_file_source rdf
 if [ "$CI" = "true" ]; then
   drush @$drush_alias sql-query "truncate watchdog;"
 fi


### PR DESCRIPTION
We are already taking care of this via features_master list and disabling here
before running front page conversion breaks some sites.