### PR TITLE
Properly handle adding extra google analytics accounts.

### DIFF
--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -155,14 +155,16 @@ if (_data_starter_validates('stage_file_proxy_origin')) {
 $conf['dkan_health_status_health_api_access_key'] = 'DKAN_HEALTH';
 
 // Add tracking codes for Google Analytics.
-if (isset($conf['gaClientTrackingCode'])) {
+if (isset($conf['gaClientTrackingCode']) && $conf['gaClientTrackingCode'] != 'UA-XXXXX-Y') {
   $conf['googleanalytics_account'] = $conf['gaClientTrackingCode'];
 }
-elseif (isset($conf['gaNuCivicTrackingCode'])) {
+elseif (isset($conf['gaNuCivicTrackingCode']) && $conf['gaNuCivicTrackingCode'] != 'UA-XXXXX-Z') {
   $conf['googleanalytics_account'] = $conf['gaNuCivicTrackingCode'];
 }
 
-if (isset($conf['gaNuCivicTrackingCode']) && $conf['googleanalytics_account'] != $conf['gaNuCivicTrackingCode']) {
+if (isset($conf['gaNuCivicTrackingCode']) &&
+  $conf['googleanalytics_account'] != $conf['gaNuCivicTrackingCode'] &&
+  $conf['gaNuCivicTrackingCode'] != 'UA-XXXXX-Z') {
   $conf['googleanalytics_codesnippet_after'] = "ga('create', '" . $conf['gaNuCivicTrackingCode'] . "', 'auto', 'nucivicTracker');ga('nucivicTracker.send', 'pageview');";
 }
 

--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -151,12 +151,20 @@ if (_data_starter_validates('stage_file_proxy_origin')) {
   $conf['stage_file_proxy_origin'] = $conf['default']['stage_file_proxy_origin'];
 }
 
-// KEY for dkan health status
+// KEY for dkan health status.
 $conf['dkan_health_status_health_api_access_key'] = 'DKAN_HEALTH';
 
 // Add tracking codes for Google Analytics.
-$conf['googleanalytics_account'] = $conf['gaClientTrackingCode'];
-$conf['googleanalytics_codesnippet_after'] = "ga('create', '" . $conf['gaNuCivicTrackingCode'] . "', 'nucivicTracker');ga('nucivicTracker.send', 'pageview');";
+if (isset($conf['gaClientTrackingCode'])) {
+  $conf['googleanalytics_account'] = $conf['gaClientTrackingCode'];
+}
+elseif (isset($conf['gaNuCivicTrackingCode'])) {
+  $conf['googleanalytics_account'] = $conf['gaNuCivicTrackingCode'];
+}
+
+if (isset($conf['gaNuCivicTrackingCode']) && $conf['googleanalytics_account'] != $conf['gaNuCivicTrackingCode']) {
+  $conf['googleanalytics_codesnippet_after'] = "ga('create', '" . $conf['gaNuCivicTrackingCode'] . "', 'auto', 'nucivicTracker');ga('nucivicTracker.send', 'pageview');";
+}
 
 // Never disallow cli access via shield config.
 $conf['shield_allow_cli'] = 1;


### PR DESCRIPTION
REF CIVIC-5862.

When no custom google analytic code is provided and the default is available use that.
If both custom and default are set make sure to add default in a manner that GA can handle.

QA Steps
==
- [ ] Verify that GA input is captured.