### PR TITLE
Civic 5761 fast import

### DIFF
--- a/assets/sites/default/settings.acquia.php
+++ b/assets/sites/default/settings.acquia.php
@@ -9,6 +9,23 @@ if (isset($conf['memcache_servers'])) {
   $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
 }
 
+// Adds support for fast file if enabled in config.yml.
+if (isset($conf['default']['fast_file']) && $conf['default']['fast_file']['enable']) {
+  $conf['dkan_datastore_fast_import_selection'] = 2;
+  $conf['dkan_datastore_fast_import_selection_threshold'] = $conf['default']['fast_file']['limit'];
+  $conf['dkan_datastore_load_data_type'] = 'load_data_local_infile';
+  $conf['queue_filesize_threshold'] = $conf['default']['fast_file']['queue'];
+  $conf['dkan_datastore_class'] = 'DkanDatastoreFastImport';
+
+  $databases['default']['default']['pdo'] = array(
+    PDO::MYSQL_ATTR_LOCAL_INFILE => 1,
+    PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => 1,
+  );
+}
+else {
+  $conf['dkan_datastore_fast_import_selection'] = 0;
+}
+
 if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
   $env = getenv('AH_SITE_ENVIRONMENT');
   $sitegroup = getenv('AH_SITE_GROUP');

--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -75,22 +75,6 @@ devinci_set_env($env_map);
 // Use the executable scan method for ClamAV by default (Daemon mode can cause some problems)
 $conf['clamav_mode'] = 1;
 
-// Adds support for fast file if enabled in config.yml.
-if (isset($conf['default']['fast_file']) && $conf['default']['fast_file']['enable']) {
-  $conf['dkan_datastore_fast_import_selection'] = 2;
-  $conf['dkan_datastore_fast_import_selection_threshold'] = $conf['default']['fast_file']['limit'];
-  $conf['dkan_datastore_load_data_type'] = 'load_data_infile';
-  $conf['queue_filesize_threshold'] = $conf['default']['fast_file']['queue'];
-  $conf['dkan_datastore_class'] = 'DkanDatastoreFastImport';
-
-  $databases['default']['default']['pdo'] = array(
-    PDO::MYSQL_ATTR_LOCAL_INFILE => 1,
-    PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => 1,
-  );
-}
-else {
-  $conf['dkan_datastore_fast_import_selection'] = 0;
-}
 
 // Don't show any errors.
 $conf['error_level'] = ERROR_REPORTING_HIDE;

--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -79,7 +79,7 @@ $conf['clamav_mode'] = 1;
 if (isset($conf['default']['fast_file']) && $conf['default']['fast_file']['enable']) {
   $conf['dkan_datastore_fast_import_selection'] = 2;
   $conf['dkan_datastore_fast_import_selection_threshold'] = $conf['default']['fast_file']['limit'];
-  $conf['dkan_datastore_load_data_type'] = 'load_data_local_infile';
+  $conf['dkan_datastore_load_data_type'] = 'load_data_infile';
   $conf['queue_filesize_threshold'] = $conf['default']['fast_file']['queue'];
   $conf['dkan_datastore_class'] = 'DkanDatastoreFastImport';
 

--- a/assets/templates/circle.yml.erb
+++ b/assets/templates/circle.yml.erb
@@ -19,6 +19,12 @@ checkout:
     # conflicts with drush.
     - rm -rf ~/.composer
 
+## Unset secure_file_priv on mysql.
+database:
+  pre:
+    - echo -e 'secure_file_priv = ""' | sudo sh -c "cat >> /etc/mysql/my.cnf"
+    - sudo /usr/sbin/service mysql restart
+
 ## Customize dependencies
 dependencies:
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,12 @@ checkout:
     # conflicts with drush.
     - rm -rf ~/.composer
 
+## Unset secure_file_priv on mysql.
+database:
+  pre:
+    - echo -e 'secure_file_priv = ""' | sudo sh -c "cat >> /etc/mysql/my.cnf"
+    - sudo /usr/sbin/service mysql restart
+
 ## Customize dependencies
 dependencies:
   cache_directories:


### PR DESCRIPTION
## Description
Reference: CIVIC-5761.
Added database settings to be able to run dkan_datastore_fast_import tests in the future.
Set the dkan_datastore_load_data_type to be load_data_infile instead of load_data_local_infile as the latter could imply security issues.

## QA Tests
- Tests passes.
