### PR TITLE
Do not set fast_import defaults in CI.

### DIFF
--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -64,6 +64,7 @@ $env_map = array(
   'prod' => 'production',
   'ra' => 'production',
 );
+define(CI, getenv('CI'));
 devinci_set_env($env_map);
 
 /********************************************************
@@ -80,11 +81,13 @@ $conf['clamav_mode'] = 1;
 
 // Adds support for fast file if enabled in config.yml.
 if (isset($conf['default']['fast_file']) && $conf['default']['fast_file']['enable']) {
-  $conf['dkan_datastore_fast_import_selection'] = 2;
-  $conf['dkan_datastore_fast_import_selection_threshold'] = $conf['default']['fast_file']['limit'];
-  $conf['dkan_datastore_load_data_type'] = 'load_data_local_infile';
-  $conf['queue_filesize_threshold'] = $conf['default']['fast_file']['queue'];
-  $conf['dkan_datastore_class'] = 'DkanDatastoreFastImport';
+  if (!CI) {
+    $conf['dkan_datastore_fast_import_selection'] = 2;
+    $conf['dkan_datastore_fast_import_selection_threshold'] = $conf['default']['fast_file']['limit'];
+    $conf['dkan_datastore_load_data_type'] = 'load_data_local_infile';
+    $conf['queue_filesize_threshold'] = $conf['default']['fast_file']['queue'];
+    $conf['dkan_datastore_class'] = 'DkanDatastoreFastImport';
+  }
 
   $databases['default']['default']['pdo'] = array(
     PDO::MYSQL_ATTR_LOCAL_INFILE => 1,
@@ -136,7 +139,6 @@ ini_set('session.cookie_lifetime', 2000000);
 
 // Disable cron. We run this from Jenkins.
 // Except for CircleCI or test purpose.
-define(CI, getenv('CI'));
 if (CI) {
   $conf['cron_safe_threshold'] = 0;
 }


### PR DESCRIPTION
REF CIVIC-6111

This should solve dkan sync PRs failing.

QA Steps
== 
- [x] tests continue to pass.