### PR TITLE
Add files htaccess CIVIC-6235

### DIFF
--- a/.ahoy/site/build.ahoy.yml
+++ b/.ahoy/site/build.ahoy.yml
@@ -135,6 +135,10 @@ commands:
       # Replace sites/default with our own sites/default outside of the drupal root.
       rm -rf docroot/sites/default;
       ln -s ../../assets/sites/default docroot/sites/default
+      # Add .htaccess to the files directory if it does not exist.
+      if [ ! -f docroot/sites/default/files/.htaccess ]; then
+        ln -s ../../config/files/.htaccess docroot/sites/default/files/.htaccess
+      fi
       # Clean out any .gitignore files imported from other modules, libraries, and profiles.
       find dkan -type f -name .gitignore -exec rm -rf {} \;
       find dkan -type d -name .git -exec rm -rf {} \;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## [1.13.3.2]
+- Support htaccess in public file directory  #232
+
 ## [1.13.3.1]
 - Fix fast import tests when fast import is disabled in config.yml #233
 - Fix notice about undefined constant CI. #233

--- a/config/files/.htaccess
+++ b/config/files/.htaccess
@@ -1,0 +1,15 @@
+# Turn off all options we don't need.
+Options None
+Options +FollowSymLinks
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>


### PR DESCRIPTION
issue: CIVIC-6235

## Description
Sites built prior to the security update for the files directory will be missing the .htaccess file and display a warning on the status page:
```
Public files directory Not fully protected
See http://drupal.org/SA-CORE-2013-003 for information about the recommended .htaccess file which should be added to the sites/default/files/ directory to help protect against arbitrary code execution.
```

We should provide that on dkan_starter