### PR TITLE
Fix fast import tests when fast import is disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## [1.13.3.1]
+- Fix fast import tests when fast import is disabled in config.yml #233
+- Fix notice about undefined constant CI. #233
+
 ## [1.13.3.0]
 - Upgrade DKAN to version 1.13.3  PR#220
 

--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -64,7 +64,7 @@ $env_map = array(
   'prod' => 'production',
   'ra' => 'production',
 );
-$ci = getenv('CI');
+define("CI", getenv('CI'));
 devinci_set_env($env_map);
 
 /********************************************************
@@ -81,7 +81,7 @@ $conf['clamav_mode'] = 1;
 
 // Adds support for fast file if enabled in config.yml.
 if (isset($conf['default']['fast_file']) && $conf['default']['fast_file']['enable']) {
-  if (!$ci) {
+  if (!CI) {
     $conf['dkan_datastore_fast_import_selection'] = 2;
     $conf['dkan_datastore_fast_import_selection_threshold'] = $conf['default']['fast_file']['limit'];
     $conf['dkan_datastore_load_data_type'] = 'load_data_local_infile';
@@ -95,7 +95,17 @@ if (isset($conf['default']['fast_file']) && $conf['default']['fast_file']['enabl
   );
 }
 else {
-  $conf['dkan_datastore_fast_import_selection'] = 0;
+  if (!CI) {
+    $conf['dkan_datastore_fast_import_selection'] = 0;
+  }
+  else {
+    // Set PDO values for CI environment and avoid setting
+    // up the fast import selection option.
+    $databases['default']['default']['pdo'] = array(
+      PDO::MYSQL_ATTR_LOCAL_INFILE => 1,
+      PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => 1,
+    );
+  }
 }
 
 // Don't show any errors.


### PR DESCRIPTION
Define CI token and avoid setting up any fast import option if we are in a CI environment or the fast import isn't enabled.

## Description
We had this issue: 

```
Notice: Use of undefined constant CI - assumed 'CI' in include_once() (line 67 of /var/www/assets/sites/default/settings.php).
```

the right way to fix it using the token was using quotes around CI because the define function expects a string as a parameter and it was incorrectly set, so here I'm setting it correctly.

Also, there is an issue with sites that have the fast import option disabled in config.yml because the dkan datastore fast import tests are still being run but they fail because some options have default values, so in this PR I'm avoiding that when we are in CI environments (so that tests passes) and when the fast import is not enabled.

## QA Tests
- [x] Tests pass.