### PR TITLE
Use CI instead of  in condition to disable cron.

### DIFF
--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -149,7 +149,7 @@ ini_set('session.cookie_lifetime', 2000000);
 
 // Disable cron. We run this from Jenkins.
 // Except for CircleCI or test purpose.
-if ($ci) {
+if (CI) {
   $conf['cron_safe_threshold'] = 0;
 }
 


### PR DESCRIPTION
## Description
The error was introduced in #233, that way the cron will never get disabled, so here I changed the condition to use the constant defined previously instead of an undefined variable.
