### PR TITLE
Set the defaut timezone to UTC in the test environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## [1.13.3.x]
+- Added date_default_timezone setting for the test env on assets/sites/default/settings.php
+
 ## [1.13.3.2]
 - Support htaccess in public file directory  #232
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change log
 
 ## [1.13.3.x]
-- Added date_default_timezone setting for the test env on assets/sites/default/settings.php
+- Added date_default_timezone setting for the test env on assets/sites/default/settings.php #244
 
 ## [1.13.3.2]
 - Support htaccess in public file directory  #232

--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -239,6 +239,8 @@ switch (ENVIRONMENT) {
 
     // Enable git support for the environment indicator to show current branch.
     $conf['environment_indicator_git_support'] = TRUE;
+    // Make sure the default timezone is set to UTC for testing.
+    $conf['date_default_timezone'] = 'UTC';
 
   case 'production':
     if (ENVIRONMENT == "test" || ENVIRONMENT == "production") {


### PR DESCRIPTION
ISSUE: CIVIC-6268

## Description
If a client site sets their default timezone to something other than UTC, the test 
```
Scenario: Replace node changed date with harvest source modified for harvested datasets
``` 
from the dataset.editor.feature file will fail.

