### PR TITLE
Add expire_panels module - required by dkan_acquia_expire

### DIFF
--- a/assets/modules/data_config/data_config.module
+++ b/assets/modules/data_config/data_config.module
@@ -81,6 +81,7 @@ function data_config_enabled_modules() {
     'environment_indicator' => 'environment_indicator',
     'eva' => 'eva',
     'expire' => 'expire',
+    'expire_panels' => 'expire_panels',
     'facet_icons' => 'facet_icons',
     'facetapi' => 'facetapi',
     'facetapi_bonus' => 'facetapi_bonus',

--- a/build.make
+++ b/build.make
@@ -89,6 +89,7 @@ projects[visualization_entity_tables][download][branch] = master
 ; Performance
 ; ===========
 projects[] = expire
+projects[] = expire_panels
 projects[] = memcache
 projects[] = entitycache
 projects[] = admin_views


### PR DESCRIPTION
## Description
HHS is pulling the latest master for `dkan_acquia_expire` which has a dependency for `expire_panels`. This update was added to `dkan_starter` in >= 1.13 but HHS is still on 1.12