### PR TITLE
Add check for resources to avoid errors when pruning

### DIFF
--- a/.ahoy/site/.scripts/utils-prune.php
+++ b/.ahoy/site/.scripts/utils-prune.php
@@ -84,12 +84,14 @@ function prune_nodes($number = 25) {
     catch(Exception $e) {
       print "Skipping dataset $node->nid do to error\n";
     }
-    foreach($resources as $resource) {
-      try {
-        node_delete($resource['target_id']);
-      }
-      catch(Exception $e) {
-        print "Skipping resource $resource[target_id] do to error\n";
+    if ($resources) {
+      foreach($resources as $resource) {
+        try {
+          node_delete($resource['target_id']);
+        }
+        catch(Exception $e) {
+          print "Skipping resource $resource[target_id] do to error\n";
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
CIVIC-6316 

When pruning the database we should check that resources exist before trying to delete them.
