### PR TITLE
Do not use bash to parse yaml.

### DIFF
--- a/.ahoy/site/.ahoy.yml
+++ b/.ahoy/site/.ahoy.yml
@@ -86,31 +86,3 @@ commands:
     usage: A series of commands for site remote management
     import: .ahoy/site/remote.ahoy.yml
     hide: true
-
-  parse:
-    usage: ahoy parse :filpath :argument, where :argument depth is seperated by underscores.
-    hide: true
-    cmd: |
-      # Attribution: https://gist.github.com/epiloque/8cf512c6d64641bde388#file-yaml-sh
-      parse_yaml() {
-        local prefix=$2
-        local s
-        local w
-        local fs
-        s='[[:space:]]*'
-        w='[a-zA-Z0-9_]*'
-        fs="$(echo @|tr @ '\034')"
-        sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
-                 -e "s|^\($s\)\($w\)$s[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" "$1" |
-        awk -F"$fs" '{
-          indent = length($1)/2;
-          vname[indent] = $2;
-          for (i in vname) {if (i > indent) {delete vname[i]}}
-            if (length($3) > 0) {
-              vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
-              printf("%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, $3);
-            }
-          }' | sed 's/_=/+=/g'
-      }
-
-      parse_yaml {{args}}

--- a/.ahoy/site/.scripts/ci-setup.rb
+++ b/.ahoy/site/.scripts/ci-setup.rb
@@ -1,0 +1,25 @@
+require "./dkan/.ahoy/.scripts/config.rb"
+
+name=`ahoy utils name`
+
+if name =~ /datastarter/
+  puts "Site name datastarter. Going with DKAN base install"
+  `ahoy site reinstall`
+else
+  puts "Site name set. Pulling database from s3 bucket"
+  `ahoy utils s3-setup`
+
+  # Configure https settings.
+  stage_file_proxy_origin = CONFIG["default"]["stage_file_proxy_origin"]
+  if  !stage_file_proxy_origin.empty?  && stage_file_proxy_origin != "changeme"
+    `ahoy utils asset-download-db`
+  else
+    `ahoy utils asset-download`
+    `ahoy utils files-link`
+  end
+
+  `ahoy utils files-fix-permissions`
+
+  # Old database should've been cleaned in the ahoy site reinstall step.
+  `ahoy drush sql-cli < backups/sanitized.sql`
+end

--- a/.ahoy/site/.scripts/deploy.rb
+++ b/.ahoy/site/.scripts/deploy.rb
@@ -2,7 +2,7 @@ require "./dkan/.ahoy/.scripts/config.rb"
 
 puts "Running drush rr --no-cache-clear"
 drush_alias = ENV['drush_alias']
-target_env = ENV['targe_env']
+target_env = ENV['target_env']
 
 `drush @#{drush_alias} rr --no-cache-clear`
 

--- a/.ahoy/site/.scripts/deploy.rb
+++ b/.ahoy/site/.scripts/deploy.rb
@@ -1,0 +1,55 @@
+require "./dkan/.ahoy/.scripts/config.rb"
+
+puts "Running drush rr --no-cache-clear"
+drush_alias = ENV['drush_alias']
+target_env = ENV['targe_env']
+
+`drush @#{drush_alias} rr --no-cache-clear`
+
+puts "Truncating cache table"
+`drush @#{drush_alias} sqlq "TRUNCATE cache;"`
+
+puts "Running database update"
+`drush @#{drush_alias} updatedb -y`
+
+puts "Clearing caches"
+`drush @#{drush_alias} cc all`
+
+puts "Checking drupal boostrap."
+drupal=`drush @#{drush_alias} status | grep -e "Drupal bootstrap" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'`
+
+if  drupal =~ /Successful/
+  puts "Installation detected, running deploy script"
+  `drush @#{drush_alias} en custom_config -y`
+  `drush @#{drush_alias} cc all`
+  `drush @#{drush_alias} -y fr --force custom_config`
+  `drush @#{drush_alias} env-switch #{target_env} --force`
+  `drush @#{drush_alias} -y updb`
+
+  db_based_search=`drush @#{drush_alias} pmi dkan_acquia_search_solr | grep disabled`
+
+  if db_based_search.nil? and db_based_search.empty?
+    puts "SOLR Search, avoiding indexing data"
+  else
+    puts "DB Search, indexing data"
+    `drush @#{drush_alias} search-api-index datasets`
+    `drush @#{drush_alias} search-api-index groups_di`
+    `drush @#{drush_alias} search-api-index stories_index`
+  end
+else
+  puts "Installation not detected"
+end
+
+# Extra non-acquia steps.
+if target_env  =~ /local/
+  `ahoy dkan create-qa-users`
+
+  password = CONFIG["private"]["probo"]["password"]
+
+  if  ENV["CI"] === "true"
+    password = "admin"
+  end
+
+  `drush --root=docroot user-password 1 --password="#{password}`
+  `drush --root=docroot user-password admin --password="#{password}`
+end

--- a/.ahoy/site/.scripts/upgrade-deploy.sh
+++ b/.ahoy/site/.scripts/upgrade-deploy.sh
@@ -18,4 +18,4 @@ if [ "$target_env" == 'local' ]; then
   drush @$drush_alias dis memcache memcache_admin -y
 fi
 
-target_env=$target_env drush_alias=$drush_alias bash .ahoy/site/.scripts/deploy.sh
+target_env=$target_env drush_alias=$drush_alias ruby .ahoy/site/.scripts/deploy.rb

--- a/.ahoy/site/.scripts/utils-asset-download-dbs.rb
+++ b/.ahoy/site/.scripts/utils-asset-download-dbs.rb
@@ -1,0 +1,16 @@
+require "./dkan/.ahoy/.scripts/config.rb"
+
+`ahoy cmd-proxy exec mkdir -p backups`
+site = `ahoy utils name`
+db = ARGV[0]
+aws_url = CONFIG["private"]["aws"]["scrubbed_data_url"]
+asset = "#{aws_url}/#{site}.prod.#{db}.sql.gz"
+
+`LC_TIME=en_US.UTF-8 perl .ahoy/site/.scripts/s3curl.pl --id local #{asset} > backups/#{db}.sql.gz`
+
+puts ""
+puts "Unpacking the $db database."
+puts ""
+
+`ahoy cmd-proxy gunzip backups/#{db}.sql.gz -f`
+`cp -f backups/#{db}.sql backups/last_install.sql`

--- a/.ahoy/site/.scripts/utils-asset-download-files.rb
+++ b/.ahoy/site/.scripts/utils-asset-download-files.rb
@@ -1,0 +1,14 @@
+require "./dkan/.ahoy/.scripts/config.rb"
+
+`ahoy cmd-proxy exec mkdir -p backups`
+site = `ahoy utils name`
+aws_url = CONFIG["private"]["aws"]["scrubbed_data_url"]
+asset = "#{aws_url}/#{site}.prod.files.tar.gz"
+
+`LC_TIME=en_US.UTF-8 perl .ahoy/site/.scripts/s3curl.pl --id local #{asset} > backups/$site.prod.files.tar.gz`
+
+puts ""
+puts "Unpacking the files asset."
+puts ""
+
+`tar xvzf backups/#{site}.prod.files.tar.gz`

--- a/.ahoy/site/ci.ahoy.yml
+++ b/.ahoy/site/ci.ahoy.yml
@@ -4,27 +4,7 @@ commands:
   setup:
     usage: switchs between ci setups
     cmd: |
-      eval $(ahoy parse config/config.yml)
-      name=$(ahoy utils name)
-
-      if [ "$name" = 'datastarter' ]; then
-        echo "Site name datastarter. Going with DKAN base install"
-        ahoy site reinstall
-      else
-        echo "Site name set. Pulling database from s3 bucket"
-        ahoy utils s3-setup
-        # Configure https settings.
-        if [ "$default_stage_file_proxy_origin" != "" ] && [ "$default_stage_file_proxy_origin" != "changeme" ]; then
-          ahoy utils asset-download-db
-        else
-          ahoy utils asset-download
-          ahoy utils files-link
-        fi
-        ahoy utils files-fix-permissions
-
-        # Old database should've been cleaned in the ahoy site reinstall step.
-        ahoy drush sql-cli < backups/sanitized.sql
-      fi
+      ruby .ahoy/site/.scripts/ci-setup.rb
 
   deploy:
     usage: deploys within a ci setup

--- a/.ahoy/site/utils.ahoy.yml
+++ b/.ahoy/site/utils.ahoy.yml
@@ -113,30 +113,12 @@ commands:
     hide: true
     usage: Download DB backup asset from S3 to local backups folder.
     cmd: |
-      eval $(ahoy parse config/config.yml)
-      ahoy cmd-proxy exec mkdir -p backups
-      site=$(ahoy utils name)
-      db={{args}}
-      asset="$private_aws_scrubbed_data_url/$site.prod.$db.sql.gz"
-      LC_TIME=en_US.UTF-8 perl .ahoy/site/.scripts/s3curl.pl --id local $asset > backups/$db.sql.gz
-      echo ""
-      echo "Unpacking the $db database."
-      echo ""
-      ahoy cmd-proxy gunzip backups/$db.sql.gz -f
-      cp -f backups/$db.sql backups/last_install.sql
+      ruby .ahoy/site/.scripts/utils-asset-download-dbs.rb {{args}}
 
   asset-download-files:
     usage: Download files backup asset from S3 to local backups folder.
     cmd: |
-      eval $(ahoy parse config/config.yml)
-      ahoy cmd-proxy exec mkdir -p backups
-      site=$(ahoy utils name)
-      asset="$private_aws_scrubbed_data_url/$site.prod.files.tar.gz"
-      LC_TIME=en_US.UTF-8 perl .ahoy/site/.scripts/s3curl.pl --id local $asset > backups/$site.prod.files.tar.gz
-      echo ""
-      echo "Unpacking the files asset."
-      echo ""
-      tar xvzf backups/$site.prod.files.tar.gz
+      ruby .ahoy/site/.scripts/utils-asset-download-files.rb
     hide: true
 
   asset-upload:


### PR DESCRIPTION
Our bash parser is broken.
Bash is awuful at parsing YAML so let's not uses.

Replaces every script that uses the bash parser with a ruby version of the
script.

Follow up may involve refactoring the ported scripts to be more rubyesque.

Acceptance
==
- [ ] `ahoy site up` works on a site with current config.yml format.