### PR TITLE
Do not skip stage file proxy if set.

### DIFF
--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -180,13 +180,11 @@ $conf['shield_allow_cli'] = 1;
 switch (ENVIRONMENT) {
   case 'local':
     if (_data_starter_validates('stage_file_proxy_origin')) {
-      if ($conf['default']['stage_file_proxy']) {
-        $conf['features_master_temp_enabled_modules'] = array_merge(
-          $conf['features_master_temp_enabled_modules'],
-          array(
-            'stage_file_proxy',
-          ));
-      }
+      $conf['features_master_temp_enabled_modules'] = array_merge(
+        $conf['features_master_temp_enabled_modules'],
+        array(
+          'stage_file_proxy',
+        ));
     }
 
     // Features Master also supports temporarily disabling modules.


### PR DESCRIPTION
REF CIVIC-6553

stage_file_proxy is being disabled even when enabled via config.

QA Steps
==
- [ ] If you enable stage file proxy by setting a proxy URL in config stage_file_proxy module is enabled.