### PR TITLE
Allow reconfiguration of behat.yml context params.

### DIFF
--- a/.ahoy/site/.scripts/build-test.rb
+++ b/.ahoy/site/.scripts/build-test.rb
@@ -1,0 +1,2 @@
+Dir.glob("./.ahoy/site/tests/test_*.rb").each {|t| puts `ruby #{t}`}
+Dir.glob("./dkan/.ahoy/tests/*.rb").each {|t| puts `ruby #{t}`}

--- a/.ahoy/site/.scripts/config-behat.rb
+++ b/.ahoy/site/.scripts/config-behat.rb
@@ -1,5 +1,6 @@
 require './dkan/.ahoy/.scripts/config.rb'
 require 'yaml'
+YAML::ENGINE.yamler = 'syck'
 
 class BehatConfig
   def initialize suite = 'dkan', config_path = 'dkan/test/behat.yml'
@@ -54,5 +55,3 @@ if ENV['PROCESS_CONFIG']
      config.dump
    }
 end
-
-

--- a/.ahoy/site/.scripts/config-behat.rb
+++ b/.ahoy/site/.scripts/config-behat.rb
@@ -45,8 +45,8 @@ end
 
 if ENV['PROCESS_CONFIG']
   {
-    #'dkan' => 'dkan/test/behat.yml',
-    #'dkan_stater' => 'tests/behat.dkan_starter.yml',
+    'dkan' => 'dkan/test/behat.yml',
+    'dkan_starter' => 'tests/behat.dkan_starter.yml',
     'custom' => 'config/tests/behat.custom.yml'
   }.each {|suite, config_path|
      config = BehatConfig.new suite, config_path

--- a/.ahoy/site/.scripts/config-behat.rb
+++ b/.ahoy/site/.scripts/config-behat.rb
@@ -1,0 +1,58 @@
+require './dkan/.ahoy/.scripts/config.rb'
+require 'yaml'
+
+class BehatConfig
+  def initialize suite = 'dkan', config_path = 'dkan/test/behat.yml'
+    @behat_config_path = config_path
+    @behat_config = YAML.load_file(@behat_config_path)
+    @default_contexts = CONFIG['behat']['contexts']
+    @contexts_key = {
+      'datasets' => 'Drupal\DKANExtension\Context\DatasetContext',
+      'services' => 'Drupal\DKANExtension\Context\ServicesContext'
+    }
+    @contexts = @behat_config['default']['suites'][suite]['contexts']
+  end
+
+  def set context, argument, value
+    c_index = @contexts.find_index {|c| c.is_a?(Hash) && c.has_key?(context)}
+    return if c_index.nil?
+    a_index = @contexts[c_index][context].find_index{|a| a.is_a?(Hash) && a.has_key?(argument)}
+    @contexts[c_index][context][a_index][argument].merge!(value)
+  end
+
+  def get context, argument
+    c_index = @contexts.find_index {|c| c.is_a?(Hash) && c.has_key?(context)}
+    return if c_index.nil?
+    a_index = @contexts[c_index][context].find_index{|a| a.is_a?(Hash) && a.has_key?(argument)}
+    @contexts[c_index][context][a_index][argument]
+  end
+
+  def process
+    @contexts_key.each {|key, context|
+      next if @default_contexts[key].nil?
+      @default_contexts[key].each{|argument, value|
+        set(context, argument, value)
+      }
+    }
+  end
+
+  def dump
+    File.open(@behat_config_path, 'w') do |file|
+      file.write(@behat_config.to_yaml.gsub(/- - (.*)/, '- [\1]'))
+    end
+  end
+end
+
+if ENV['PROCESS_CONFIG']
+  {
+    #'dkan' => 'dkan/test/behat.yml',
+    #'dkan_stater' => 'tests/behat.dkan_starter.yml',
+    'custom' => 'config/tests/behat.custom.yml'
+  }.each {|suite, config_path|
+     config = BehatConfig.new suite, config_path
+     config.process
+     config.dump
+   }
+end
+
+

--- a/.ahoy/site/.scripts/config.php
+++ b/.ahoy/site/.scripts/config.php
@@ -1,24 +1,25 @@
 <?php
+
 /**
+ * @file
  * Transpose config.yml to php array.
  */
 
-include realpath(__DIR__ . '/../vendor/autoload.php');
+include './.ahoy/site/vendor/autoload.php';
 
 use Symfony\Component\Yaml\Parser;
-use Symfony\Component\Yaml\Dumper;
 
 // Setup twig.
-$loader = new Twig_Loader_Filesystem(realpath(__DIR__ . '/../.templates'));
+$loader = new Twig_Loader_Filesystem('.ahoy/site/.templates');
 $twig = new Twig_Environment($loader, array(
-    'cache' => realpath(__DIR__ . '/../.cache'),
+  'cache' => './ahoy/site/.cache',
 ));
 $twig->addFunction(new Twig_SimpleFunction('var_export', 'var_export'));
 
 try {
   // Parse yaml.
   $yaml = new Parser();
-  $config = $yaml->parse(file_get_contents(__DIR__ . '/../../../config/config.yml'));
+  $config = $yaml->parse(file_get_contents('./config/config.yml'));
 
   // Render yaml using twig template.
   $context = array(
@@ -30,13 +31,13 @@ try {
   );
 
   // Write the php file.
-  $file = fopen(__DIR__ . '/../../../config/config.php', 'w');
+  $file = fopen('./config/config.php', 'w');
   fwrite($file, $output);
-} catch (Exception $e) {
+}
+catch (Exception $e) {
   echo "An error happened trying to transpose the config.yml file:\n{$e->getMessage()}\n";
 } finally {
   if ($file) {
     fclose($file);
   }
 }
-

--- a/.ahoy/site/build.ahoy.yml
+++ b/.ahoy/site/build.ahoy.yml
@@ -166,11 +166,13 @@ commands:
       ahoy cmd-proxy ruby .ahoy/site/.scripts/htaccess.rb
       ahoy cmd-proxy ruby .ahoy/site/.scripts/circle.rb
       ahoy cmd-proxy PROCESS_CONFIG=true ruby .ahoy/site/.scripts/config.rb
+      ahoy cmd-proxy PROCESS_CONFIG=true ruby .ahoy/site/.scripts/config-behat.rb
 
       # Transpose config.yml to php
       cd .ahoy/site
       composer install
-      php .scripts/config.php
+      cd -
+      ahoy cmd-proxy php .ahoy/site/.scripts/config.php
 
   new:
     usage: Sets new client site from dkan-starter
@@ -290,3 +292,8 @@ commands:
     upgrade-sites:
       usage: ahoy build upgrade-sites $tag
       cmd: ahoy cmd-proxy bash .ahoy/site/.scripts/upgrade-sites.sh
+
+  test:
+    usage: Run some build command tests 
+    cmd: ahoy cmd-proxy ruby .ahoy/site/.scripts/build-test.rb
+    

--- a/.ahoy/site/tests/test_config-behat.rb
+++ b/.ahoy/site/tests/test_config-behat.rb
@@ -1,0 +1,53 @@
+require "minitest/autorun"
+require "./.ahoy/site/.scripts/config-behat.rb"
+
+class TestConfig < MiniTest::Unit::TestCase
+  def setup
+    CONFIG["behat"]["contexts"]["datasets"] = {"fields" => {}}
+    @context = "Drupal\\DKANExtension\\Context\\DatasetContext"
+    @config = BehatConfig.new
+  end
+
+  def test_default_argument_value
+    expected = "title"
+    actual = @config.get(@context, "fields")["title"]
+    assert_equal expected, actual
+  end
+
+  def test_override_argument_value
+    @config.set(@context, "fields", {"title" => "foo"})
+    expected = "foo"
+    actual = @config.get(@context, "fields")["title"]
+    assert_equal expected, actual
+  end
+
+  def test_add_new_argument_value
+    @config.set(@context, "fields", {"bar" => "none"})
+    expected = "none"
+    actual = @config.get(@context, "fields")["bar"]
+    assert_equal expected, actual
+  end
+
+  def test_process_smoke
+    @config.process
+    expected = "title"
+    actual = @config.get(@context, "fields")["title"]
+    assert_equal expected, actual
+  end
+
+  def test_process_overrides
+    CONFIG["behat"]["contexts"]["datasets"] = {"fields" => {"title" => "foo"}}
+    @config.process
+    expected = "foo"
+    actual = @config.get(@context, "fields")["title"]
+    assert_equal expected, actual
+  end
+
+  def test_process_add
+    CONFIG["behat"]["contexts"]["datasets"] = {"fields" => {"foo" => "bar"}}
+    @config.process
+    expected = "bar"
+    actual = @config.get(@context, "fields")["foo"]
+    assert_equal expected, actual
+  end
+end

--- a/.ahoy/site/tests/test_config.rb
+++ b/.ahoy/site/tests/test_config.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "./.scripts/config.rb"
+require "./.ahoy/site/.scripts/config.rb"
 
 
 class TestConfig < MiniTest::Unit::TestCase

--- a/assets/templates/circle.yml.erb
+++ b/assets/templates/circle.yml.erb
@@ -45,7 +45,7 @@ dependencies:
     - ahoy site up --db-user=ubuntu --db-pass='' --db-host=127.0.0.1 --db-port=3306 --db-name=circle_test
     - ahoy utils fail-when-bad-disable
     # Run a webserver using drush.
-    - 'ahoy dkan server':
+    - 'ahoy drush --yes runserver :8888':
         background: true
 
     - wget http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar
@@ -61,6 +61,8 @@ test:
     - BEHAT_FOLDER=$HOME/$CIRCLE_PROJECT_REPONAME/tests ruby dkan/.ahoy/.scripts/circle-behat.rb <%= @test_dirs.join(" ") %> --tags='<%= @skip_tags.join("&&") %>':
         timeout: 1200
         parallel: true
+    - ahoy build test:
+        parallel: false
   post:
     - echo $CIRCLE_ARTIFACTS; cp -av tests/assets $CIRCLE_ARTIFACTS:
         parallel: true

--- a/assets/templates/circle.yml.erb
+++ b/assets/templates/circle.yml.erb
@@ -35,8 +35,6 @@ dependencies:
     - echo "always_populate_raw_post_data = -1" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/deprecated.ini
     - sudo apt-get update -y && sudo apt-get install -y x11vnc clamav clamav-freshclam
     - yes | sudo perl -MCPAN -e "install Digest::HMAC_SHA1;"
-    - ahoy dkan server:
-      background: true
 
   override:
     - printenv
@@ -46,10 +44,8 @@ dependencies:
     - drush dl -n registry_rebuild-7.x
     - ahoy site up --db-user=ubuntu --db-pass='' --db-host=127.0.0.1 --db-port=3306 --db-name=circle_test
     - ahoy utils fail-when-bad-disable
-    # Run a webserver using drush.
-    - 'ahoy drush --yes runserver :8888':
+    - 'PATH=/home/ubuntu/.config/composer/vendor/bin:$PATH ahoy dkan server':
         background: true
-
     - wget http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar
     - java -jar selenium-server-standalone-2.53.1.jar -p 4444 :
         background: true

--- a/assets/templates/circle.yml.erb
+++ b/assets/templates/circle.yml.erb
@@ -35,6 +35,8 @@ dependencies:
     - echo "always_populate_raw_post_data = -1" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/deprecated.ini
     - sudo apt-get update -y && sudo apt-get install -y x11vnc clamav clamav-freshclam
     - yes | sudo perl -MCPAN -e "install Digest::HMAC_SHA1;"
+    - ahoy dkan server:
+      background: true
 
   override:
     - printenv

--- a/build-dkan.make
+++ b/build-dkan.make
@@ -11,3 +11,4 @@ projects[dkan][download][url] = https://github.com/NuCivic/dkan.git
 projects[dkan][download][tag] = 7.x-1.13.5
 
 projects[dkan][patch][] = https://patch-diff.githubusercontent.com/raw/NuCivic/dkan/pull/2018.diff
+projects[dkan][patch][] = https://patch-diff.githubusercontent.com/raw/NuCivic/dkan/pull/2025.diff

--- a/circle.yml
+++ b/circle.yml
@@ -45,7 +45,7 @@ dependencies:
     - ahoy site up --db-user=ubuntu --db-pass='' --db-host=127.0.0.1 --db-port=3306 --db-name=circle_test
     - ahoy utils fail-when-bad-disable
     # Run a webserver using drush.
-    - 'ahoy dkan server':
+    - 'ahoy drush --yes runserver :8888':
         background: true
 
     - wget http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar
@@ -61,6 +61,8 @@ test:
     - BEHAT_FOLDER=$HOME/$CIRCLE_PROJECT_REPONAME/tests ruby dkan/.ahoy/.scripts/circle-behat.rb tests/features dkan/test/features config/tests/features --tags='~@customizable&&~@fixme&&~@testBug':
         timeout: 1200
         parallel: true
+    - ahoy build test:
+        parallel: false
   post:
     - echo $CIRCLE_ARTIFACTS; cp -av tests/assets $CIRCLE_ARTIFACTS:
         parallel: true

--- a/circle.yml
+++ b/circle.yml
@@ -35,8 +35,6 @@ dependencies:
     - echo "always_populate_raw_post_data = -1" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/deprecated.ini
     - sudo apt-get update -y && sudo apt-get install -y x11vnc clamav clamav-freshclam
     - yes | sudo perl -MCPAN -e "install Digest::HMAC_SHA1;"
-    - ahoy dkan server:
-      background: true
 
   override:
     - printenv
@@ -46,10 +44,8 @@ dependencies:
     - drush dl -n registry_rebuild-7.x
     - ahoy site up --db-user=ubuntu --db-pass='' --db-host=127.0.0.1 --db-port=3306 --db-name=circle_test
     - ahoy utils fail-when-bad-disable
-    # Run a webserver using drush.
-    - 'ahoy drush --yes runserver :8888':
+    - 'PATH=/home/ubuntu/.config/composer/vendor/bin:$PATH ahoy dkan server':
         background: true
-
     - wget http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar
     - java -jar selenium-server-standalone-2.53.1.jar -p 4444 :
         background: true

--- a/circle.yml
+++ b/circle.yml
@@ -35,6 +35,8 @@ dependencies:
     - echo "always_populate_raw_post_data = -1" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/deprecated.ini
     - sudo apt-get update -y && sudo apt-get install -y x11vnc clamav clamav-freshclam
     - yes | sudo perl -MCPAN -e "install Digest::HMAC_SHA1;"
+    - ahoy dkan server:
+      background: true
 
   override:
     - printenv

--- a/config/config.php
+++ b/config/config.php
@@ -38,6 +38,33 @@ $conf = array (
       'derived_key' => 'changeme',
     ),
   ),
+  'behat' => 
+  array (
+    'contexts' => 
+    array (
+      'datasets' => 
+      array (
+        'defaults' => 
+        array (
+        ),
+        'fields' => 
+        array (
+        ),
+        'labels' => 
+        array (
+        ),
+        'sets' => 
+        array (
+        ),
+      ),
+      'services' => 
+      array (
+        'request_fields_map' => 
+        array (
+        ),
+      ),
+    ),
+  ),
   'circle' => 
   array (
     'memory_limit' => '256M',

--- a/config/config.yml
+++ b/config/config.yml
@@ -20,6 +20,15 @@ acquia:
     base_url: http://testurl
     core_id: changeme
     derived_key: changeme
+behat:
+  contexts:
+    datasets:
+      defaults: {}
+      fields: {}
+      labels: {}
+      sets: {}
+    services:
+      request_fields_map: {}
 circle:
   memory_limit: 256M
   skip_features: []

--- a/config/tests/behat.custom.yml
+++ b/config/tests/behat.custom.yml
@@ -1,12 +1,12 @@
-# behat.yml
+---
 default:
   suites:
     custom:
       paths:
-        - %paths.base%/../config/tests/features
+      - ! '%paths.base%/../config/tests/features'
       contexts:
-        - CustomContext
-        - FeatureContext #Temporary overrides only!
-        - Drupal\DrupalExtension\Context\MinkContext
-        - Drupal\DrupalExtension\Context\DrupalContext
-        - Drupal\DrupalExtension\Context\MessageContext
+      - CustomContext
+      - FeatureContext
+      - Drupal\DrupalExtension\Context\MinkContext
+      - Drupal\DrupalExtension\Context\DrupalContext
+      - Drupal\DrupalExtension\Context\MessageContext

--- a/config/tests/behat.custom.yml
+++ b/config/tests/behat.custom.yml
@@ -1,10 +1,10 @@
----
-default:
-  suites:
-    custom:
-      paths:
-      - ! '%paths.base%/../config/tests/features'
-      contexts:
+--- 
+default: 
+  suites: 
+    custom: 
+      paths: 
+      - "%paths.base%/../config/tests/features"
+      contexts: 
       - CustomContext
       - FeatureContext
       - Drupal\DrupalExtension\Context\MinkContext

--- a/dkan/.ahoy/tests/behat-parse-params.rb
+++ b/dkan/.ahoy/tests/behat-parse-params.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "./.scripts/behat-parse-params.rb"
+require "./dkan/.ahoy/.scripts/behat-parse-params.rb"
 
 class TestBehatParseParams < MiniTest::Unit::TestCase
 

--- a/dkan/modules/contrib/open_data_schema_map/modules/open_data_schema_pod/podValidator.php
+++ b/dkan/modules/contrib/open_data_schema_map/modules/open_data_schema_pod/podValidator.php
@@ -34,7 +34,7 @@ class validate {
         $this->dataJSON->dataset = $this->dataset;
       }
       else {
-        throw new Exception(t("POD validator could not access %url", array("%url" => $this->url)));
+        throw new \Exception(t("POD validator could not access %url", array("%url" => $this->url)));
       }
     }
   }

--- a/dkan/test/behat.yml
+++ b/dkan/test/behat.yml
@@ -123,65 +123,65 @@ default:
       tags: ~@fixme
   extensions: 
     Behat\MinkExtension: 
-      goutte: 
-      selenium2: 
+      goutte: "~"
+      selenium2: "~"
       default_session: goutte
       javascript_session: selenium2
       browser_name: chrome
       files_path: "%paths.base%/files"
     Drupal\DrupalExtension: 
-      blackbox: 
+      blackbox: "~"
       drupal: 
         drupal_root: "%paths.base%/../../docroot"
       api_driver: drupal
       region_map: 
-        content: .view-content
-        toolbar: .tabs--primary
-        footer: "#footer"
-        header: "#header"
-        modal: "#modalContent"
-        left header: "#header-left"
-        right header: "#header-right"
-        right sidebar: "#column-right"
-        dashboards: .view-data-dashboards table tbody
-        navigation: .navigation-wrapper
+        admin menu: "#admin-menu"
         breadcrumb: .breadcrumb
-        left_sidebar: .panel-col-first
-        dataset title: .pane-node .pane-title
-        dataset resource list: "#data-and-resources"
+        comment: .comment-main
+        content search: .form-item-query
+        content: .region-content
+        dashboards: .view-data-dashboards table tbody
         dataset body: .field-name-body
         dataset edit body: "#edit-body"
+        dataset resource list: "#data-and-resources"
         dataset spatial: "#edit-field-spatial"
-        resource title: .pane-node .pane-title
-        resource groups: "#edit-groups"
-        search_area: .panel-col-last
+        dataset title: .pane-node .pane-title
+        datasets: .view-dkan-datasets
         dropdown_links: .comment-main .links.inline.dropdown-menu
-        comment: .comment-main
-        primary tabs: .tabs--primary
-        group subscribe: .group-subscribe-message
+        facet container: .radix-layouts-sidebar
+        filter by author: .facetapi-facet-author
+        filter by date changed: .facetapi-facet-changed
+        filter by resource format: .facetapi-facet-field-resourcesfield-format
+        filter by tag: .facetapi-facet-field-tags
+        filter by topics: .facetapi-facet-field-topic
+        footer: "#footer"
         group block: .pane-views-group-block-block
         group members: .view-id-dkan_og_extras_group_members
-        facet container: .radix-layouts-sidebar
-        filter by resource format: .facetapi-facet-field-resourcesfield-format
-        filter by author: .facetapi-facet-author
-        filter by topics: .facetapi-facet-field-topic
-        filter by tag: .facetapi-facet-field-tags
-        filter by date changed: .facetapi-facet-changed
-        social: .pane-dkan-sitewide-dkan-sitewide-social
-        other access: .pane-dkan-sitewide-dkan-sitewide-other-access
-        datasets: .view-dkan-datasets
-        user profile: .pane-dkan-sitewide-panels-dkan-user-summary
-        results: .view-header
-        user page: .main
-        user command center: .pane-dkan-sitewide-profile-page-dkan-user-summary
-        tabs: .field-group-htabs-wrapper
+        group subscribe: .group-subscribe-message
         groups: .view-content
-        search content results: .content
-        user content: .view-user-profile-search
-        content search: .form-item-query
-        user block: .pane-views-user-profile-fields-block
-        admin menu: "#admin-menu"
         harvest datasets: .view-dkan-harvest-datasets
+        header: "#header"
+        left header: "#header-left"
+        left_sidebar: .panel-col-first
+        modal: "#modalContent"
+        navigation: .navigation-wrapper
+        other access: .pane-dkan-sitewide-dkan-sitewide-other-access
+        primary tabs: .tabs--primary
+        resource groups: "#edit-groups"
+        resource title: .pane-node .pane-title
+        results: .view-header
+        right header: "#header-right"
+        right sidebar: "#column-right"
+        search content results: .content
+        search_area: .panel-col-last
+        social: .pane-dkan-sitewide-dkan-sitewide-social
+        tabs: .field-group-htabs-wrapper
+        toolbar: .tabs--primary
+        user block: .pane-views-user-profile-fields-block
+        user command center: .pane-dkan-sitewide-profile-page-dkan-user-summary
+        user content: .view-user-profile-search
+        user page: .main
+        user profile: .pane-dkan-sitewide-panels-dkan-user-summary
       text: 
         log_out: Log out
         log_in: Log in

--- a/dkan/test/behat.yml
+++ b/dkan/test/behat.yml
@@ -33,7 +33,6 @@ default:
             license: field_license
             doi: field_doi
             citation: field_citation
-            corn: stop
         - labels: 
             title: Title
             body: Description
@@ -85,7 +84,7 @@ default:
               title: title
               body: body[und][0][value]
               status: status
-            dataset': 
+            dataset: 
               type: type
               title: title
               status: status
@@ -133,7 +132,7 @@ default:
     Drupal\DrupalExtension: 
       blackbox: 
       drupal: 
-        drupal_root: rpaths.base%/../../docroot
+        drupal_root: "%paths.base%/../../docroot"
       api_driver: drupal
       region_map: 
         content: .view-content

--- a/dkan/test/behat.yml
+++ b/dkan/test/behat.yml
@@ -1,8 +1,8 @@
----
-default:
-  suites:
-    dkan:
-      contexts:
+--- 
+default: 
+  suites: 
+    dkan: 
+      contexts: 
       - FeatureContext
       - Drupal\DrupalExtension\Context\MinkContext
       - Drupal\DrupalExtension\Context\DrupalContext
@@ -15,8 +15,8 @@ default:
       - Drupal\DKANExtension\Context\GroupContext
       - Drupal\DKANExtension\Context\HarvestSourceContext
       - Drupal\DKANExtension\Context\WorkflowContext
-      - Drupal\DKANExtension\Context\DatasetContext:
-        - fields:
+      - Drupal\DKANExtension\Context\DatasetContext: 
+        - fields: 
             title: title
             description: body
             published: status
@@ -34,7 +34,7 @@ default:
             doi: field_doi
             citation: field_citation
             corn: stop
-        - labels:
+        - labels: 
             title: Title
             body: Description
             field_tags: Tags
@@ -56,36 +56,36 @@ default:
             field_conforms_to: Data Standard
             field_language: Language
             og_group_ref: Groups
-        - sets:
+        - sets: 
             field_spatial: Spatial / Geographical Coverage Area
             field_temporal_coverage: Temporal Coverage
-        - defaults:
+        - defaults: 
             field_public_access_level: public
             field_hhs_attestation_negative: 1
             field_license: odc-by
       - Drupal\DKANExtension\Context\DataDashboardContext
       - Drupal\DKANExtension\Context\PODContext
       - Drupal\DKANExtension\Context\FastImportContext
-      - Drupal\DKANExtension\Context\SearchAPIContext:
-          search_forms:
-            default:
-              form_css: ! '#dkan-sitewide-dataset-search-form'
+      - Drupal\DKANExtension\Context\SearchAPIContext: 
+          search_forms: 
+            default: 
+              form_css: "#dkan-sitewide-dataset-search-form"
               form_field: edit-search
               form_button: edit-submit
               results_css: .view-dkan-datasets
               result_item_css: .views-row
-            harvest_source:
+            harvest_source: 
               results_css: .view-dkan-harvest-source-search
               result_item_css: .views-row
       - Drupal\DKANExtension\Context\ResourceContext
-      - Drupal\DKANExtension\Context\ServicesContext:
-        - request_fields_map:
-            resource:
+      - Drupal\DKANExtension\Context\ServicesContext: 
+        - request_fields_map: 
+            resource: 
               type: type
               title: title
               body: body[und][0][value]
               status: status
-            dataset':
+            dataset': 
               type: type
               title: title
               status: status
@@ -108,53 +108,53 @@ default:
       - Drupal\DKANExtension\Context\DatastoreContext
       - Drupal\DKANExtension\Context\TimezoneContext
       - Drupal\DrupalExtension\Context\DrushContext
-      - Devinci\DevinciExtension\Context\DebugContext:
-          asset_dump_path: ! '%paths.base%/assets'
-      - Devinci\DevinciExtension\Context\JavascriptContext:
+      - Devinci\DevinciExtension\Context\DebugContext: 
+          asset_dump_path: "%paths.base%/assets"
+      - Devinci\DevinciExtension\Context\JavascriptContext: 
           maximum_wait: 30
-  formatters:
-    pretty:
-      output_styles:
-        comment:
+  formatters: 
+    pretty: 
+      output_styles: 
+        comment: 
         - default
         - default
         - [conceal]
-  gherkin:
-    filters:
+  gherkin: 
+    filters: 
       tags: ~@fixme
-  extensions:
-    Behat\MinkExtension:
+  extensions: 
+    Behat\MinkExtension: 
       goutte: 
       selenium2: 
       default_session: goutte
       javascript_session: selenium2
       browser_name: chrome
-      files_path: ! '%paths.base%/files'
-    Drupal\DrupalExtension:
+      files_path: "%paths.base%/files"
+    Drupal\DrupalExtension: 
       blackbox: 
-      drupal:
-        drupal_root: ! '%paths.base%/../../docroot'
+      drupal: 
+        drupal_root: rpaths.base%/../../docroot
       api_driver: drupal
-      region_map:
+      region_map: 
         content: .view-content
         toolbar: .tabs--primary
-        footer: ! '#footer'
-        header: ! '#header'
-        modal: ! '#modalContent'
-        left header: ! '#header-left'
-        right header: ! '#header-right'
-        right sidebar: ! '#column-right'
+        footer: "#footer"
+        header: "#header"
+        modal: "#modalContent"
+        left header: "#header-left"
+        right header: "#header-right"
+        right sidebar: "#column-right"
         dashboards: .view-data-dashboards table tbody
         navigation: .navigation-wrapper
         breadcrumb: .breadcrumb
         left_sidebar: .panel-col-first
         dataset title: .pane-node .pane-title
-        dataset resource list: ! '#data-and-resources'
+        dataset resource list: "#data-and-resources"
         dataset body: .field-name-body
-        dataset edit body: ! '#edit-body'
-        dataset spatial: ! '#edit-field-spatial'
+        dataset edit body: "#edit-body"
+        dataset spatial: "#edit-field-spatial"
         resource title: .pane-node .pane-title
-        resource groups: ! '#edit-groups'
+        resource groups: "#edit-groups"
         search_area: .panel-col-last
         dropdown_links: .comment-main .links.inline.dropdown-menu
         comment: .comment-main
@@ -181,14 +181,14 @@ default:
         user content: .view-user-profile-search
         content search: .form-item-query
         user block: .pane-views-user-profile-fields-block
-        admin menu: ! '#admin-menu'
+        admin menu: "#admin-menu"
         harvest datasets: .view-dkan-harvest-datasets
-      text:
+      text: 
         log_out: Log out
         log_in: Log in
-      selectors:
+      selectors: 
         message_selector: .alert
         error_message_selector: .alert.alert-error
         success_message_selector: .alert.alert-success
-    Drupal\DKANExtension:
+    Drupal\DKANExtension: 
       some_param: test

--- a/dkan/test/behat.yml
+++ b/dkan/test/behat.yml
@@ -14,7 +14,54 @@ default:
           - Drupal\DKANExtension\Context\GroupContext
           - Drupal\DKANExtension\Context\HarvestSourceContext
           - Drupal\DKANExtension\Context\WorkflowContext
-          - Drupal\DKANExtension\Context\DatasetContext
+          - Drupal\DKANExtension\Context\DatasetContext:
+            - fields:
+                title: title
+                description: body
+                published: status
+                resource: field_resources
+                access level: field_public_access_level
+                contact name: field_contact_name
+                contact email: field_contact_email
+                attest name: field_hhs_attestation_name
+                attest date: field_hhs_attestation_date
+                verification status: field_hhs_attestation_negative
+                attest privacy: field_hhs_attestation_privacy
+                attest quality: field_hhs_attestation_quality
+                bureau code: field_odfe_bureau_code
+                license: field_license
+                doi: field_doi
+                citation: field_citation
+                corn: stop
+            - labels:
+                title: Title
+                body: Description
+                field_tags: Tags
+                field_topics: Topics
+                field_license: License
+                field_author: Author
+                field_spatial_geographical_cover: Spatial / Geographical Coverage Location
+                field_frequency: Frequency
+                field_granularity: Granularity
+                field_data_dictionary_type: Data Dictionary Type
+                field_data_dictionary: Data Dictionary
+                field_contact_name: Contact Name
+                field_contact_email: Contact Email
+                field_public_access_level: Public Access Level
+                field_additional_info: Additional Info
+                field_resources: Resources
+                field_related_content: Related Content
+                field_landing_page: Homepage URL
+                field_conforms_to: Data Standard
+                field_language: Language
+                og_group_ref: Groups
+            - sets:
+                field_spatial: Spatial / Geographical Coverage Area
+                field_temporal_coverage: Temporal Coverage
+            - defaults:
+                field_public_access_level: public
+                field_hhs_attestation_negative: 1
+                field_license: odc-by
           - Drupal\DKANExtension\Context\DataDashboardContext
           - Drupal\DKANExtension\Context\PODContext
           - Drupal\DKANExtension\Context\FastImportContext
@@ -30,13 +77,38 @@ default:
                   results_css: '.view-dkan-harvest-source-search'
                   result_item_css: '.views-row'
           - Drupal\DKANExtension\Context\ResourceContext
-          - Drupal\DKANExtension\Context\ServicesContext
+          - Drupal\DKANExtension\Context\ServicesContext:
+            - request_fields_map:
+                resource:
+                  type: type
+                  title: title
+                  body: body[und][0][value]
+                  status: status
+                dataset':
+                  type: type
+                  title: title
+                  status: status
+                  published: status
+                  body: body[und][0][value]
+                  resource: field_resources[und][0][target_id]
+                  access level: field_public_access_level[und]
+                  contact name: field_contact_name[und][0][value]
+                  contact email: field_contact_email[und][0][value]
+                  attest name: field_hhs_attestation_name[und][0][value]
+                  attest date: field_hhs_attestation_date[und][0][value][date]
+                  verification status: field_hhs_attestation_negative[und]
+                  attest privacy: field_hhs_attestation_privacy[und]
+                  attest quality: field_hhs_attestation_quality[und]
+                  bureau code: field_odfe_bureau_code[und]
+                  license: field_license[und][select]
+                  doi: field_doi[und][0][value]
+                  citation: field_citation[und][0][value]
           - Drupal\DKANExtension\Context\PODContext
           - Drupal\DKANExtension\Context\DatastoreContext
           - Drupal\DKANExtension\Context\TimezoneContext
           - Drupal\DrupalExtension\Context\DrushContext
           - Devinci\DevinciExtension\Context\DebugContext:
-              asset_dump_path: %paths.base%/assets
+              asset_dump_path: '%paths.base%/assets'
           - Devinci\DevinciExtension\Context\JavascriptContext:
               maximum_wait: 30
   formatters:
@@ -53,12 +125,12 @@ default:
       default_session: 'goutte'
       javascript_session: 'selenium2'
       browser_name: chrome
-      files_path: %paths.base%/files
+      files_path: '%paths.base%/files'
     Drupal\DrupalExtension:
       blackbox: ~
       drupal:
         #TODO Abstract this out.
-        drupal_root: %paths.base%/../../docroot
+        drupal_root: '%paths.base%/../../docroot'
       api_driver: 'drupal'
       # @todo fixup these regions for use with new theme. Updated navigation only
       region_map:

--- a/dkan/test/behat.yml
+++ b/dkan/test/behat.yml
@@ -123,8 +123,10 @@ default:
       tags: ~@fixme
   extensions: 
     Behat\MinkExtension: 
-      goutte: 
-      selenium2: 
+      goutte: []
+
+      selenium2: []
+
       default_session: goutte
       javascript_session: selenium2
       browser_name: chrome

--- a/dkan/test/behat.yml
+++ b/dkan/test/behat.yml
@@ -123,14 +123,14 @@ default:
       tags: ~@fixme
   extensions: 
     Behat\MinkExtension: 
-      goutte: "~"
-      selenium2: "~"
+      goutte: 
+      selenium2: 
       default_session: goutte
       javascript_session: selenium2
       browser_name: chrome
       files_path: "%paths.base%/files"
     Drupal\DrupalExtension: 
-      blackbox: "~"
+      blackbox: 
       drupal: 
         drupal_root: "%paths.base%/../../docroot"
       api_driver: drupal

--- a/dkan/test/behat.yml
+++ b/dkan/test/behat.yml
@@ -1,194 +1,194 @@
+---
 default:
   suites:
-     dkan:
-        contexts:
-          - FeatureContext #Temporary overrides only!
-          - Drupal\DrupalExtension\Context\MinkContext
-          - Drupal\DrupalExtension\Context\DrupalContext
-          - Drupal\DrupalExtension\Context\MessageContext
-          - Drupal\DrupalExtension\Context\MarkupContext
-          - Drupal\DrupalExtension\Context\BatchContext
-          - Drupal\DKANExtension\Context\DKANContext
-          - Drupal\DKANExtension\Context\MailContext
-          - Drupal\DKANExtension\Context\PageContext
-          - Drupal\DKANExtension\Context\GroupContext
-          - Drupal\DKANExtension\Context\HarvestSourceContext
-          - Drupal\DKANExtension\Context\WorkflowContext
-          - Drupal\DKANExtension\Context\DatasetContext:
-            - fields:
-                title: title
-                description: body
-                published: status
-                resource: field_resources
-                access level: field_public_access_level
-                contact name: field_contact_name
-                contact email: field_contact_email
-                attest name: field_hhs_attestation_name
-                attest date: field_hhs_attestation_date
-                verification status: field_hhs_attestation_negative
-                attest privacy: field_hhs_attestation_privacy
-                attest quality: field_hhs_attestation_quality
-                bureau code: field_odfe_bureau_code
-                license: field_license
-                doi: field_doi
-                citation: field_citation
-                corn: stop
-            - labels:
-                title: Title
-                body: Description
-                field_tags: Tags
-                field_topics: Topics
-                field_license: License
-                field_author: Author
-                field_spatial_geographical_cover: Spatial / Geographical Coverage Location
-                field_frequency: Frequency
-                field_granularity: Granularity
-                field_data_dictionary_type: Data Dictionary Type
-                field_data_dictionary: Data Dictionary
-                field_contact_name: Contact Name
-                field_contact_email: Contact Email
-                field_public_access_level: Public Access Level
-                field_additional_info: Additional Info
-                field_resources: Resources
-                field_related_content: Related Content
-                field_landing_page: Homepage URL
-                field_conforms_to: Data Standard
-                field_language: Language
-                og_group_ref: Groups
-            - sets:
-                field_spatial: Spatial / Geographical Coverage Area
-                field_temporal_coverage: Temporal Coverage
-            - defaults:
-                field_public_access_level: public
-                field_hhs_attestation_negative: 1
-                field_license: odc-by
-          - Drupal\DKANExtension\Context\DataDashboardContext
-          - Drupal\DKANExtension\Context\PODContext
-          - Drupal\DKANExtension\Context\FastImportContext
-          - Drupal\DKANExtension\Context\SearchAPIContext:
-              search_forms:
-                default:
-                  form_css: '#dkan-sitewide-dataset-search-form'
-                  form_field: 'edit-search'
-                  form_button: 'edit-submit'
-                  results_css: '.view-dkan-datasets'
-                  result_item_css: '.views-row'
-                harvest_source:
-                  results_css: '.view-dkan-harvest-source-search'
-                  result_item_css: '.views-row'
-          - Drupal\DKANExtension\Context\ResourceContext
-          - Drupal\DKANExtension\Context\ServicesContext:
-            - request_fields_map:
-                resource:
-                  type: type
-                  title: title
-                  body: body[und][0][value]
-                  status: status
-                dataset':
-                  type: type
-                  title: title
-                  status: status
-                  published: status
-                  body: body[und][0][value]
-                  resource: field_resources[und][0][target_id]
-                  access level: field_public_access_level[und]
-                  contact name: field_contact_name[und][0][value]
-                  contact email: field_contact_email[und][0][value]
-                  attest name: field_hhs_attestation_name[und][0][value]
-                  attest date: field_hhs_attestation_date[und][0][value][date]
-                  verification status: field_hhs_attestation_negative[und]
-                  attest privacy: field_hhs_attestation_privacy[und]
-                  attest quality: field_hhs_attestation_quality[und]
-                  bureau code: field_odfe_bureau_code[und]
-                  license: field_license[und][select]
-                  doi: field_doi[und][0][value]
-                  citation: field_citation[und][0][value]
-          - Drupal\DKANExtension\Context\PODContext
-          - Drupal\DKANExtension\Context\DatastoreContext
-          - Drupal\DKANExtension\Context\TimezoneContext
-          - Drupal\DrupalExtension\Context\DrushContext
-          - Devinci\DevinciExtension\Context\DebugContext:
-              asset_dump_path: '%paths.base%/assets'
-          - Devinci\DevinciExtension\Context\JavascriptContext:
-              maximum_wait: 30
+    dkan:
+      contexts:
+      - FeatureContext
+      - Drupal\DrupalExtension\Context\MinkContext
+      - Drupal\DrupalExtension\Context\DrupalContext
+      - Drupal\DrupalExtension\Context\MessageContext
+      - Drupal\DrupalExtension\Context\MarkupContext
+      - Drupal\DrupalExtension\Context\BatchContext
+      - Drupal\DKANExtension\Context\DKANContext
+      - Drupal\DKANExtension\Context\MailContext
+      - Drupal\DKANExtension\Context\PageContext
+      - Drupal\DKANExtension\Context\GroupContext
+      - Drupal\DKANExtension\Context\HarvestSourceContext
+      - Drupal\DKANExtension\Context\WorkflowContext
+      - Drupal\DKANExtension\Context\DatasetContext:
+        - fields:
+            title: title
+            description: body
+            published: status
+            resource: field_resources
+            access level: field_public_access_level
+            contact name: field_contact_name
+            contact email: field_contact_email
+            attest name: field_hhs_attestation_name
+            attest date: field_hhs_attestation_date
+            verification status: field_hhs_attestation_negative
+            attest privacy: field_hhs_attestation_privacy
+            attest quality: field_hhs_attestation_quality
+            bureau code: field_odfe_bureau_code
+            license: field_license
+            doi: field_doi
+            citation: field_citation
+            corn: stop
+        - labels:
+            title: Title
+            body: Description
+            field_tags: Tags
+            field_topics: Topics
+            field_license: License
+            field_author: Author
+            field_spatial_geographical_cover: Spatial / Geographical Coverage Location
+            field_frequency: Frequency
+            field_granularity: Granularity
+            field_data_dictionary_type: Data Dictionary Type
+            field_data_dictionary: Data Dictionary
+            field_contact_name: Contact Name
+            field_contact_email: Contact Email
+            field_public_access_level: Public Access Level
+            field_additional_info: Additional Info
+            field_resources: Resources
+            field_related_content: Related Content
+            field_landing_page: Homepage URL
+            field_conforms_to: Data Standard
+            field_language: Language
+            og_group_ref: Groups
+        - sets:
+            field_spatial: Spatial / Geographical Coverage Area
+            field_temporal_coverage: Temporal Coverage
+        - defaults:
+            field_public_access_level: public
+            field_hhs_attestation_negative: 1
+            field_license: odc-by
+      - Drupal\DKANExtension\Context\DataDashboardContext
+      - Drupal\DKANExtension\Context\PODContext
+      - Drupal\DKANExtension\Context\FastImportContext
+      - Drupal\DKANExtension\Context\SearchAPIContext:
+          search_forms:
+            default:
+              form_css: ! '#dkan-sitewide-dataset-search-form'
+              form_field: edit-search
+              form_button: edit-submit
+              results_css: .view-dkan-datasets
+              result_item_css: .views-row
+            harvest_source:
+              results_css: .view-dkan-harvest-source-search
+              result_item_css: .views-row
+      - Drupal\DKANExtension\Context\ResourceContext
+      - Drupal\DKANExtension\Context\ServicesContext:
+        - request_fields_map:
+            resource:
+              type: type
+              title: title
+              body: body[und][0][value]
+              status: status
+            dataset':
+              type: type
+              title: title
+              status: status
+              published: status
+              body: body[und][0][value]
+              resource: field_resources[und][0][target_id]
+              access level: field_public_access_level[und]
+              contact name: field_contact_name[und][0][value]
+              contact email: field_contact_email[und][0][value]
+              attest name: field_hhs_attestation_name[und][0][value]
+              attest date: field_hhs_attestation_date[und][0][value][date]
+              verification status: field_hhs_attestation_negative[und]
+              attest privacy: field_hhs_attestation_privacy[und]
+              attest quality: field_hhs_attestation_quality[und]
+              bureau code: field_odfe_bureau_code[und]
+              license: field_license[und][select]
+              doi: field_doi[und][0][value]
+              citation: field_citation[und][0][value]
+      - Drupal\DKANExtension\Context\PODContext
+      - Drupal\DKANExtension\Context\DatastoreContext
+      - Drupal\DKANExtension\Context\TimezoneContext
+      - Drupal\DrupalExtension\Context\DrushContext
+      - Devinci\DevinciExtension\Context\DebugContext:
+          asset_dump_path: ! '%paths.base%/assets'
+      - Devinci\DevinciExtension\Context\JavascriptContext:
+          maximum_wait: 30
   formatters:
     pretty:
       output_styles:
-        comment:    [default, default , [conceal]]
+        comment:
+        - default
+        - default
+        - [conceal]
   gherkin:
     filters:
       tags: ~@fixme
   extensions:
     Behat\MinkExtension:
-      goutte: ~
-      selenium2: ~
-      default_session: 'goutte'
-      javascript_session: 'selenium2'
+      goutte: 
+      selenium2: 
+      default_session: goutte
+      javascript_session: selenium2
       browser_name: chrome
-      files_path: '%paths.base%/files'
+      files_path: ! '%paths.base%/files'
     Drupal\DrupalExtension:
-      blackbox: ~
+      blackbox: 
       drupal:
-        #TODO Abstract this out.
-        drupal_root: '%paths.base%/../../docroot'
-      api_driver: 'drupal'
-      # @todo fixup these regions for use with new theme. Updated navigation only
+        drupal_root: ! '%paths.base%/../../docroot'
+      api_driver: drupal
       region_map:
-        content: ".region-content"
-        toolbar: ".tabs--primary"
-        footer: "#footer"
-        header: "#header"
-        modal: "#modalContent"
-        left header: "#header-left"
-        right header: "#header-right"
-        right sidebar: "#column-right"
-        dashboards: ".view-data-dashboards table tbody"
-        navigation: '.navigation-wrapper'
-        breadcrumb: '.breadcrumb'
-        left_sidebar: '.panel-col-first'
-        dataset title: '.pane-node .pane-title'
-        dataset resource list: '#data-and-resources'
-        dataset body: '.field-name-body'
-        dataset edit body: '#edit-body'
-        dataset spatial: '#edit-field-spatial'
-        resource title: '.pane-node .pane-title'
-        resource groups: '#edit-groups'
-        search_area: '.panel-col-last'
-        dropdown_links: '.comment-main .links.inline.dropdown-menu'
-        comment: '.comment-main'
-        navigation: '.navigation-wrapper'
-        primary tabs: '.tabs--primary'
-        group subscribe: '.group-subscribe-message'
-        group block: '.pane-views-group-block-block'
-        group members: '.view-id-dkan_og_extras_group_members'
-        facet container: '.radix-layouts-sidebar'
-        filter by resource format: '.facetapi-facet-field-resourcesfield-format'
-        filter by author: '.facetapi-facet-author'
-        filter by topics: '.facetapi-facet-field-topic'
-        filter by tag: '.facetapi-facet-field-tags'
-        filter by date changed: '.facetapi-facet-changed'
-        social: '.pane-dkan-sitewide-dkan-sitewide-social'
-        other access: '.pane-dkan-sitewide-dkan-sitewide-other-access'
-        datasets: '.view-dkan-datasets'
-        user profile: '.pane-dkan-sitewide-panels-dkan-user-summary'
-        results: '.view-header'
-        user page: '.main'
-        user command center: '.pane-dkan-sitewide-profile-page-dkan-user-summary'
-        tabs: '.field-group-htabs-wrapper'
-        content: '.view-content'
-        groups: '.view-content'
-        search content results: '.content'
-        user content: '.view-user-profile-search'
-        content search: '.form-item-query'
-        user block: '.pane-views-user-profile-fields-block'
-        admin menu: '#admin-menu'
-        harvest datasets: '.view-dkan-harvest-datasets'
+        content: .view-content
+        toolbar: .tabs--primary
+        footer: ! '#footer'
+        header: ! '#header'
+        modal: ! '#modalContent'
+        left header: ! '#header-left'
+        right header: ! '#header-right'
+        right sidebar: ! '#column-right'
+        dashboards: .view-data-dashboards table tbody
+        navigation: .navigation-wrapper
+        breadcrumb: .breadcrumb
+        left_sidebar: .panel-col-first
+        dataset title: .pane-node .pane-title
+        dataset resource list: ! '#data-and-resources'
+        dataset body: .field-name-body
+        dataset edit body: ! '#edit-body'
+        dataset spatial: ! '#edit-field-spatial'
+        resource title: .pane-node .pane-title
+        resource groups: ! '#edit-groups'
+        search_area: .panel-col-last
+        dropdown_links: .comment-main .links.inline.dropdown-menu
+        comment: .comment-main
+        primary tabs: .tabs--primary
+        group subscribe: .group-subscribe-message
+        group block: .pane-views-group-block-block
+        group members: .view-id-dkan_og_extras_group_members
+        facet container: .radix-layouts-sidebar
+        filter by resource format: .facetapi-facet-field-resourcesfield-format
+        filter by author: .facetapi-facet-author
+        filter by topics: .facetapi-facet-field-topic
+        filter by tag: .facetapi-facet-field-tags
+        filter by date changed: .facetapi-facet-changed
+        social: .pane-dkan-sitewide-dkan-sitewide-social
+        other access: .pane-dkan-sitewide-dkan-sitewide-other-access
+        datasets: .view-dkan-datasets
+        user profile: .pane-dkan-sitewide-panels-dkan-user-summary
+        results: .view-header
+        user page: .main
+        user command center: .pane-dkan-sitewide-profile-page-dkan-user-summary
+        tabs: .field-group-htabs-wrapper
+        groups: .view-content
+        search content results: .content
+        user content: .view-user-profile-search
+        content search: .form-item-query
+        user block: .pane-views-user-profile-fields-block
+        admin menu: ! '#admin-menu'
+        harvest datasets: .view-dkan-harvest-datasets
       text:
-        log_out: "Log out"
-        log_in: "Log in"
+        log_out: Log out
+        log_in: Log in
       selectors:
-        message_selector: '.alert'
-        error_message_selector: '.alert.alert-error'
-        success_message_selector: '.alert.alert-success'
+        message_selector: .alert
+        error_message_selector: .alert.alert-error
+        success_message_selector: .alert.alert-success
     Drupal\DKANExtension:
       some_param: test

--- a/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/DatasetContext.php
+++ b/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/DatasetContext.php
@@ -16,29 +16,15 @@ class DatasetContext extends RawDKANEntityContext {
   /**
    *
    */
-  public function __construct() {
+  public function __construct($fields, $labels = array(), $sets = array(), $defaults = array()) {
+    $this->datasetFieldLabels = $labels['labels'];
+    $this->datasetFieldSets = $sets['sets'];
+    $this->datasetFieldDefaults = $defaults['defaults'];
+
     parent::__construct(
       'node',
       'dataset',
-      // ToDo: load this from custom context.https://github.com/NuCivic/dkan_starter/issues/332.
-      array(
-        'title' => 'title',
-        'description' => 'body',
-        'published' => 'status',
-        'resource' => 'field_resources',
-        'access level' => 'field_public_access_level',
-        'contact name' => 'field_contact_name',
-        'contact email' => 'field_contact_email',
-        'attest name' => 'field_hhs_attestation_name',
-        'attest date' => 'field_hhs_attestation_date',
-        'verification status' => 'field_hhs_attestation_negative',
-        'attest privacy' => 'field_hhs_attestation_privacy',
-        'attest quality' => 'field_hhs_attestation_quality',
-        'bureau code' => 'field_odfe_bureau_code',
-        'license' => 'field_license',
-        'doi' => 'field_doi',
-        'citation' => 'field_citation',
-      ),
+      $fields['fields'],
       array(
         'moderation',
         'moderation_date',
@@ -278,35 +264,8 @@ class DatasetContext extends RawDKANEntityContext {
 
     // We could use field_info_instances() to get the list of fields for the 'dataset' content
     // type but that would not cover the case where a field is removed accidentally.
-    $dataset_fields = array(
-      'title' => 'Title',
-      'body' => 'Description',
-      'field_tags' => 'Tags',
-      'field_topics' => 'Topics',
-      'field_license' => 'License',
-      'field_author' => 'Author',
-      'field_spatial_geographical_cover' => 'Spatial / Geographical Coverage Location',
-      'field_frequency' => 'Frequency',
-      'field_granularity' => 'Granularity',
-      'field_data_dictionary_type' => 'Data Dictionary Type',
-      'field_data_dictionary' => 'Data Dictionary',
-      'field_contact_name' => 'Contact Name',
-      'field_contact_email' => 'Contact Email',
-      'field_public_access_level' => 'Public Access Level',
-      'field_additional_info' => 'Additional Info',
-      'field_resources' => 'Resources',
-      'field_related_content' => 'Related Content',
-      'field_landing_page' => 'Homepage URL',
-      'field_conforms_to' => 'Data Standard',
-      'field_language' => 'Language',
-      'og_group_ref' => 'Groups',
-    );
-
-    $dataset_fieldsets = array(
-      'field_spatial' => 'Spatial / Geographical Coverage Area',
-      'field_temporal_coverage' => 'Temporal Coverage',
-    );
-
+    $dataset_fields = $this->datasetFieldLabels;
+    $dataset_fieldsets = $this->datasetFieldSets;
     // Get all available form fields.
     // Searching by the Label as a text on the page is not enough since a text like 'Resources'
     // could appear because other reasons.

--- a/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/PODContext.php
+++ b/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/PODContext.php
@@ -36,7 +36,7 @@ class PODContext extends RawDKANContext {
   {
     $data_json = open_data_schema_map_api_load('data_json_1_1');
     // Get base URL.
-    $url = $this->getMinkParameter('base_url') ? $this->getMinkParameter('base_url') : "http://127.0.0.1::8888";
+    $url = $this->getMinkParameter('base_url') ? $this->getMinkParameter('base_url') : "http://127.0.0.1:8888";
 
     // Validate POD.
     $results = open_data_schema_pod_process_validate($url . '/data.json', TRUE);

--- a/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
+++ b/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANContext.php
@@ -98,7 +98,7 @@ class RawDKANContext extends RawDrupalContext implements DKANAwareInterface {
       foreach ($proxy_files as $file) {
         $source = $conf['default']['stage_file_proxy_origin'] . '/' . $file;
         $destination = 'public://' . $file;
-        $copy($source, $destination);
+        copy($source, $destination);
       }
     }
     variable_set('stage_file_proxy_setup', TRUE);

--- a/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -458,16 +458,13 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
           continue;
         }
 
+        $defaults = $this->datasetFieldDefaults;
+
         if (isset($field['required']) && $field['required']) {
           $k = array_search($key, $this->field_map);
           if (!isset($data[$k])) {
             $data[$k] = $devel_generate_wrapper->$key->value();
-            // TODO: use param passed in from behat config for defaults.
-            $defaults = array(
-              'field_public_access_level' => 'public',
-              'field_hhs_attestation_negative' => 1,
-              'field_license' => 'odc-by',
-            );
+            $defaults = $this->datasetFieldDefaults;
             foreach ($defaults as $default => $value) {
               if ($key == $default) {
                 $data[$k] = $value;

--- a/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
+++ b/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
@@ -19,34 +19,11 @@ class ServicesContext extends RawDKANContext {
   /**
    * TODO: Move to configuration passed in to constructor.
    */
-  private $request_fields_map = array(
-    'resource' => array(
-      'type' => 'type',
-      'title' => 'title',
-      'body' => 'body[und][0][value]',
-      'status' => 'status',
-    ),
-    'dataset' => array(
-      'type' => 'type',
-      'title' => 'title',
-      'status' => 'status',
-      'published' => 'status',
-      'body' => 'body[und][0][value]',
-      'resource' => 'field_resources[und][0][target_id]',
-      'access level' => 'field_public_access_level[und]',
-      'contact name' => 'field_contact_name[und][0][value]',
-      'contact email' => 'field_contact_email[und][0][value]',
-      'attest name' => 'field_hhs_attestation_name[und][0][value]',
-      'attest date' => 'field_hhs_attestation_date[und][0][value][date]',
-      'verification status' => 'field_hhs_attestation_negative[und]',
-      'attest privacy' => 'field_hhs_attestation_privacy[und]',
-      'attest quality' => 'field_hhs_attestation_quality[und]',
-      'bureau code' => 'field_odfe_bureau_code[und]',
-      'license' => 'field_license[und][select]',
-      'doi' => 'field_doi[und][0][value]',
-      'citation' => 'field_citation[und][0][value]',
-    ),
-  );
+  private $request_fields_map;
+
+  public function __construct($request_fields_map = array()) {
+    $this->request_fields_map = $request_fields_map['request_fields_map'];
+  }
 
   /**
    * @BeforeScenario

--- a/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
+++ b/dkan/test/dkanextension/src/Drupal/DKANExtension/Context/ServicesContext.php
@@ -32,6 +32,7 @@ class ServicesContext extends RawDKANContext {
     parent::gatherContexts($scope);
     $environment = $scope->getEnvironment();
     $this->dkanContext = $environment->getContext('Drupal\DKANExtension\Context\DKANContext');
+    $this->datasetContext = $environment->getContext('Drupal\DKANExtension\Context\DatasetContext');
   }
 
   /**
@@ -380,8 +381,7 @@ class ServicesContext extends RawDKANContext {
     $rest_api_fields = $this->request_fields_map[$node_type];
 
     if ($node_type == "dataset") {
-      $rawDkanEntityContext = new DatasetContext();
-      $rawDkanEntityContext->applyMissingRequiredFields($data);
+      $this->datasetContext->applyMissingRequiredFields($data);
     }
 
     foreach ($data as $field => $field_value) {

--- a/tests/behat.dkan_starter.yml
+++ b/tests/behat.dkan_starter.yml
@@ -1,14 +1,14 @@
----
-default:
-  autoload:
-  - ! '%paths.base%/features/bootstrap/custom'
-  - ! '%paths.base%/features/bootstrap/dkan'
-  - ! '%paths.base%/features/bootstrap'
-  suites:
-    dkan_starter:
-      paths:
-      - ! '%paths.base%/features'
-      contexts:
+--- 
+default: 
+  autoload: 
+  - "%paths.base%/features/bootstrap/custom"
+  - "%paths.base%/features/bootstrap/dkan"
+  - "%paths.base%/features/bootstrap"
+  suites: 
+    dkan_starter: 
+      paths: 
+      - "%paths.base%/features"
+      contexts: 
       - FeatureContext
       - Drupal\DrupalExtension\Context\MinkContext
       - Drupal\DrupalExtension\Context\DrupalContext
@@ -19,8 +19,8 @@ default:
       - Drupal\DKANExtension\Context\PageContext
       - Drupal\DKANExtension\Context\GroupContext
       - Drupal\DKANExtension\Context\WorkflowContext
-      - Drupal\DKANExtension\Context\DatasetContext:
-        - fields:
+      - Drupal\DKANExtension\Context\DatasetContext: 
+        - fields: 
             title: title
             description: body
             published: status
@@ -38,7 +38,7 @@ default:
             doi: field_doi
             citation: field_citation
             corn: stop
-        - labels:
+        - labels: 
             title: Title
             body: Description
             field_tags: Tags
@@ -60,10 +60,10 @@ default:
             field_conforms_to: Data Standard
             field_language: Language
             og_group_ref: Groups
-        - sets:
+        - sets: 
             field_spatial: Spatial / Geographical Coverage Area
             field_temporal_coverage: Temporal Coverage
-        - defaults:
+        - defaults: 
             field_public_access_level: public
             field_hhs_attestation_negative: 1
             field_license: odc-by
@@ -71,15 +71,15 @@ default:
       - Drupal\DKANExtension\Context\ResourceContext
       - Drupal\DKANExtension\Context\DatastoreContext
       - Drupal\DKANExtension\Context\SearchAPIContext: 
-        search_forms:
-          default:
-            form_css: ! '#dkan-sitewide-dataset-search-form'
+        search_forms: 
+          default: 
+            form_css: "#dkan-sitewide-dataset-search-form"
             form_field: edit-search
             form_button: edit-submit
             results_css: .view-dkan-datasets
             result_item_css: .views-row
-      - Devinci\DevinciExtension\Context\JavascriptContext:
+      - Devinci\DevinciExtension\Context\JavascriptContext: 
           maximum_wait: 30
-    dkan:
-      paths:
-      - ! '%paths.base%/../dkan/test/features'
+    dkan: 
+      paths: 
+      - "%paths.base%/../dkan/test/features"

--- a/tests/behat.dkan_starter.yml
+++ b/tests/behat.dkan_starter.yml
@@ -37,7 +37,6 @@ default:
             license: field_license
             doi: field_doi
             citation: field_citation
-            corn: stop
         - labels: 
             title: Title
             body: Description

--- a/tests/behat.dkan_starter.yml
+++ b/tests/behat.dkan_starter.yml
@@ -1,43 +1,85 @@
-# this default param refers to a profile level configuration
+---
 default:
-  # autoloads can only be handled in behat using PS-0 at the profile level
-  # otherwise use composer.json and PS-3
   autoload:
-    # PS-0 forces us to use a symlink inside of the profile level bootstrap
-    - %paths.base%/features/bootstrap/custom
-    - %paths.base%/features/bootstrap/dkan
-    - %paths.base%/features/bootstrap
+  - ! '%paths.base%/features/bootstrap/custom'
+  - ! '%paths.base%/features/bootstrap/dkan'
+  - ! '%paths.base%/features/bootstrap'
   suites:
-    # this default parram is for a suite level configuration
     dkan_starter:
       paths:
-        - %paths.base%/features
+      - ! '%paths.base%/features'
       contexts:
-        - FeatureContext
-        - Drupal\DrupalExtension\Context\MinkContext
-        - Drupal\DrupalExtension\Context\DrupalContext
-        - Drupal\DrupalExtension\Context\MessageContext
-        - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DKANExtension\Context\DKANContext
-        - Drupal\DKANExtension\Context\MailContext
-        - Drupal\DKANExtension\Context\PageContext
-        - Drupal\DKANExtension\Context\GroupContext
-        - Drupal\DKANExtension\Context\WorkflowContext
-        - Drupal\DKANExtension\Context\DatasetContext
-        - Drupal\DKANExtension\Context\DataDashboardContext
-        - Drupal\DKANExtension\Context\ResourceContext
-        - Drupal\DKANExtension\Context\DatastoreContext
-        - Drupal\DKANExtension\Context\SearchAPIContext:
-          search_forms:
-            default:
-              form_css: '#dkan-sitewide-dataset-search-form'
-              form_field: 'edit-search'
-              form_button: 'edit-submit'
-              results_css: '.view-dkan-datasets'
-              result_item_css: '.views-row'
-        - Devinci\DevinciExtension\Context\JavascriptContext:
-              maximum_wait: 30
+      - FeatureContext
+      - Drupal\DrupalExtension\Context\MinkContext
+      - Drupal\DrupalExtension\Context\DrupalContext
+      - Drupal\DrupalExtension\Context\MessageContext
+      - Drupal\DrupalExtension\Context\MarkupContext
+      - Drupal\DKANExtension\Context\DKANContext
+      - Drupal\DKANExtension\Context\MailContext
+      - Drupal\DKANExtension\Context\PageContext
+      - Drupal\DKANExtension\Context\GroupContext
+      - Drupal\DKANExtension\Context\WorkflowContext
+      - Drupal\DKANExtension\Context\DatasetContext:
+        - fields:
+            title: title
+            description: body
+            published: status
+            resource: field_resources
+            access level: field_public_access_level
+            contact name: field_contact_name
+            contact email: field_contact_email
+            attest name: field_hhs_attestation_name
+            attest date: field_hhs_attestation_date
+            verification status: field_hhs_attestation_negative
+            attest privacy: field_hhs_attestation_privacy
+            attest quality: field_hhs_attestation_quality
+            bureau code: field_odfe_bureau_code
+            license: field_license
+            doi: field_doi
+            citation: field_citation
+            corn: stop
+        - labels:
+            title: Title
+            body: Description
+            field_tags: Tags
+            field_topics: Topics
+            field_license: License
+            field_author: Author
+            field_spatial_geographical_cover: Spatial / Geographical Coverage Location
+            field_frequency: Frequency
+            field_granularity: Granularity
+            field_data_dictionary_type: Data Dictionary Type
+            field_data_dictionary: Data Dictionary
+            field_contact_name: Contact Name
+            field_contact_email: Contact Email
+            field_public_access_level: Public Access Level
+            field_additional_info: Additional Info
+            field_resources: Resources
+            field_related_content: Related Content
+            field_landing_page: Homepage URL
+            field_conforms_to: Data Standard
+            field_language: Language
+            og_group_ref: Groups
+        - sets:
+            field_spatial: Spatial / Geographical Coverage Area
+            field_temporal_coverage: Temporal Coverage
+        - defaults:
+            field_public_access_level: public
+            field_hhs_attestation_negative: 1
+            field_license: odc-by
+      - Drupal\DKANExtension\Context\DataDashboardContext
+      - Drupal\DKANExtension\Context\ResourceContext
+      - Drupal\DKANExtension\Context\DatastoreContext
+      - Drupal\DKANExtension\Context\SearchAPIContext: 
+        search_forms:
+          default:
+            form_css: ! '#dkan-sitewide-dataset-search-form'
+            form_field: edit-search
+            form_button: edit-submit
+            results_css: .view-dkan-datasets
+            result_item_css: .views-row
+      - Devinci\DevinciExtension\Context\JavascriptContext:
+          maximum_wait: 30
     dkan:
-      # handle dkan path here to maintain backwards compatibility
       paths:
-        - %paths.base%/../dkan/test/features
+      - ! '%paths.base%/../dkan/test/features'


### PR DESCRIPTION
REF CIVIC-6614 nucivic/dkan#2025 #332

Adds some new build tools to allow sites to override behat cotext attributes
with custom settings set in cofig.yml

See `.ahoy/site/tests/test_config-behat.rb` for details of how this works, but the gist of it is
you add overriding configurations in config.yml

```
behat:
  contexts:
    datasets:
      defaults: {}
      fields: {}
      labels: {}
      sets: {}
    services:
      request_fields_map: {}
```

And this gets incorporated into the various behat.yml settings by running

```
ahoy build config`
```

QA Steps
===
- [ ] run `ahoy build test`, if when tests pass... check out file in `.ahoy/site/tests/test_config-behat.rb` verify you understand what is going on and how this works.
- [ ] If you wish recreate those tests manually yourself and verify they work.


Required PRS.
===
- [ ] nucivic/dkan#2025

as per usual.