### PR TITLE
Add ODSM edit paths to $high_memory_paths in settings.acquia.php

### DIFF
--- a/assets/sites/default/settings.acquia.php
+++ b/assets/sites/default/settings.acquia.php
@@ -62,6 +62,7 @@ if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
       'node/%node/moderation',
       'file/ajax',
       'api/action/datastore/search.json',
+      'admin/config/services/odsm/edit',
     );
 
     // Standarize node edit paths for validation.

--- a/assets/sites/default/settings.acquia.php
+++ b/assets/sites/default/settings.acquia.php
@@ -69,6 +69,7 @@ if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
   
   // ODSM edit forms.
   $high_memory_paths[] = 'admin/config/services/odsm/edit';
+
   // Standarize node edit paths for validation.
   $current_path = preg_replace("/\/\d+/", '/%node', $_GET['q']);
   foreach ($high_memory_paths as $high_memory_path) {

--- a/assets/sites/default/settings.acquia.php
+++ b/assets/sites/default/settings.acquia.php
@@ -53,24 +53,27 @@ if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
     );
   }
 
-  // {{{1 Conditionally manage memory.
+  // Conditionally manage memory.
+  $high_memory_paths = array();
+  // Things that break in ODFE.
   if (isset($conf['default']['odfe']) && $conf['default']['odfe']['enabled']) {
-    $high_memory_paths = array(
+    $high_memory_paths += array(
       'admin',
       'node/add',
       'node/%node/edit',
       'node/%node/moderation',
       'file/ajax',
       'api/action/datastore/search.json',
-      'admin/config/services/odsm/edit',
     );
-
-    // Standarize node edit paths for validation.
-    $current_path = preg_replace("/\d+/", '%node', $_GET['q']);
-    foreach ($high_memory_paths as $high_memory_path) {
-      if ((strpos($current_path, $high_memory_path) === 0)) {
-        ini_set('memory_limit', '512M');
-      }
+  }
+  
+  // ODSM edit forms.
+  $high_memory_paths[] = 'admin/config/services/odsm/edit';
+  // Standarize node edit paths for validation.
+  $current_path = preg_replace("/\/\d+/", '/%node', $_GET['q']);
+  foreach ($high_memory_paths as $high_memory_path) {
+    if ((strpos($current_path, $high_memory_path) === 0)) {
+      ini_set('memory_limit', '512M');
     }
   }
 


### PR DESCRIPTION
## Description

ODSM edit forms were exhausting the memory on Acquia sites that only have 128mb memory by default. This PR increases the memory allocation for these forms, and cleans up the surrounding code a bit.

Fixes NuCivic/dkan#1974

## QA Tests

1. Deploy to an acquia site running dkan_starter
2. Open Configuration > Web Services > Open Data Schema Mapper, and try to edit the data_json_1_1 API. You should be able to both load and submit the form.