### PR TITLE
Fixed deploy script

### DIFF
--- a/.ahoy/site/.scripts/upgrade-deploy.sh
+++ b/.ahoy/site/.scripts/upgrade-deploy.sh
@@ -3,13 +3,17 @@ echo "Target environment is $target_env"
 echo "Drush alias is $drush_alias"
 
 upgrade_version=upgrade_1_13
-upgrade_status=`drush @$drush_alias vget $upgrade_version --exact`
+upgrade_status=`drush @$drush_alias vget $upgrade_version --exact |tr -d '\n'`
 
-if [ -z $upgrade_status ]; then
+echo "The upgrade status is $upgrade_status"
+
+if [ -z "$upgrade_status" ]; then
   upgrade_status='never upgraded';
 fi
 
+
 if [ "$upgrade_status" != 'upgraded' ]; then
+  echo "The site was not upgraded. Running $upgrade_version.sh"
   target_env=$target_env drush_alias=$drush_alias bash .ahoy/site/.scripts/upgrades/$upgrade_version.sh
   drush @$drush_alias vset $upgrade_version upgraded
 fi


### PR DESCRIPTION
## Description

The "upgrade_status" variable contained a "\n" character so the later comparison with "upgraded" failed and the upgrade script was executed again.

## QA Tests

- [x] Tests should pass.