### PR TITLE
Fix site variable interpolation during asset download

### DIFF
--- a/.ahoy/site/.scripts/utils-asset-download-files.rb
+++ b/.ahoy/site/.scripts/utils-asset-download-files.rb
@@ -5,7 +5,7 @@ site = `ahoy utils name`
 aws_url = CONFIG["private"]["aws"]["scrubbed_data_url"]
 asset = "#{aws_url}/#{site}.prod.files.tar.gz"
 
-`LC_TIME=en_US.UTF-8 perl .ahoy/site/.scripts/s3curl.pl --id local #{asset} > backups/$site.prod.files.tar.gz`
+`LC_TIME=en_US.UTF-8 perl .ahoy/site/.scripts/s3curl.pl --id local #{asset} > backups/ #{site}.prod.files.tar.gz`
 
 puts ""
 puts "Unpacking the files asset."


### PR DESCRIPTION
## Description
Site variable was using the bash interpolation instead of the ruby one. That was causing the file's backup filename not being prepended with the sitename. 