### PR TITLE
Add seckit module to dkan_starter.

### DIFF
--- a/assets/modules/data_config/data_config.module
+++ b/assets/modules/data_config/data_config.module
@@ -258,6 +258,10 @@ function data_config_enabled_modules() {
     $features_master['modules']['strongarm'] = 'strongarm';
     $features_master['modules']['text'] = 'text';
   }
+
+  if (isset($data_config['seckit']) && $data_config['seckit']['enable']) {
+    $features_master['modules']['seckit'] = 'seckit';
+  }
   return $features_master;
 
 }

--- a/assets/sites/default/settings.php
+++ b/assets/sites/default/settings.php
@@ -164,6 +164,18 @@ if (_data_starter_validates('stage_file_proxy_origin')) {
   $conf['stage_file_proxy_origin'] = $conf['default']['stage_file_proxy_origin'];
 }
 
+// Configure Security Kit If Enabled.
+$data_config = variable_get('default');
+if (isset($data_config['seckit']) && $data_config['seckit']['enable']) {
+  $seckit_ssl = array(
+    'hsts' => $conf['default']['seckit']['hsts'],
+    'hsts_max_age' => $conf['default']['seckit']['hsts_max_age'],
+    'hsts_sudomains' => $conf['default']['seckit']['hsts_subdomains'],
+  );
+
+  $conf['seckit_ssl'] = $seckit_ssl;
+}
+
 // KEY for dkan health status.
 $conf['dkan_health_status_health_api_access_key'] = 'DKAN_HEALTH';
 

--- a/build.make
+++ b/build.make
@@ -91,6 +91,7 @@ projects[clamav][version] = 1.x-dev
 projects[clamav][subdir] = contrib
 
 projects[] = role_watchdog
+projects[seckit] = 1.9
 
 ; Other
 ; ======

--- a/config/config.php
+++ b/config/config.php
@@ -107,6 +107,13 @@ $conf = array (
     array (
       'enable' => false,
     ),
+    'seckit' => 
+    array (
+      'enable' => false,
+      'hsts' => 1,
+      'hsts_max_age' => '1000',
+      'hsts_subdomains' => 0,
+    ),
     'stage_file_proxy_files' => 
     array (
     ),

--- a/config/config.yml
+++ b/config/config.yml
@@ -54,6 +54,11 @@ default:
   https_securepages: false
   odfe:
     enable: false
+  seckit:
+    enable: false
+    hsts: 1
+    hsts_max_age: '1000'
+    hsts_subdomains: 0
   stage_file_proxy_files: []
   stage_file_proxy_origin: changeme
 dkan_dash: []

--- a/dkan/libraries/symfonyserializer/Mapping/Loader/YamlFileLoader.php
+++ b/dkan/libraries/symfonyserializer/Mapping/Loader/YamlFileLoader.php
@@ -15,7 +15,6 @@ use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 use Symfony\Component\Yaml\Parser;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * YAML File Loader.
@@ -114,7 +113,7 @@ class YamlFileLoader extends FileLoader
             $this->yamlParser = new Parser();
         }
 
-        $classes = $this->yamlParser->parse(file_get_contents($this->file), Yaml::PARSE_KEYS_AS_STRINGS);
+        $classes = $this->yamlParser->parse(file_get_contents($this->file));
 
         if (empty($classes)) {
             return array();

--- a/docroot/sites/all/modules/contrib/seckit/LICENSE.txt
+++ b/docroot/sites/all/modules/contrib/seckit/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/docroot/sites/all/modules/contrib/seckit/css/seckit.no_body.css
+++ b/docroot/sites/all/modules/contrib/seckit/css/seckit.no_body.css
@@ -1,0 +1,6 @@
+/**
+ * Hide <body> element.
+ */
+body {
+  display: none !important;
+}

--- a/docroot/sites/all/modules/contrib/seckit/css/seckit.noscript_tag.css
+++ b/docroot/sites/all/modules/contrib/seckit/css/seckit.noscript_tag.css
@@ -1,0 +1,26 @@
+/**
+ * Override style of seckit.no_body.css to show div with message.
+ */
+body {
+  display: block !important;
+}
+
+/**
+ * Set style of div with message
+ * "Sorry, you need to enable JavaScript to visit this website."
+ * so it hides all site behind itself.
+ */
+#seckit-noscript-tag {
+  background-color: white;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  height: 100% !important;
+  width: 100% !important;
+  z-index: 999 !important;
+  font-family: sans-serif;
+  font-weight: bold;
+  color: red;
+  text-align: center;
+  padding-top: 20px;
+}

--- a/docroot/sites/all/modules/contrib/seckit/includes/seckit.form.inc
+++ b/docroot/sites/all/modules/contrib/seckit/includes/seckit.form.inc
@@ -1,0 +1,430 @@
+<?php
+/**
+ * @file
+ * Administrative interface for SecKit settings.
+ */
+
+/**
+ * Forms administration page.
+ */
+function seckit_admin_form() {
+  // Get default/configured (and unaltered) options.
+  if ($hooks = module_implements('seckit_options_alter')) {
+    foreach ($hooks as $key => $module) {
+      $hooks[$key] = $module . '_seckit_options_alter()';
+    }
+    drupal_set_message(t("Some settings may be overridden at runtime. See @hooks.", array('@hooks' => implode(', ', $hooks))), 'status', FALSE);
+    $options = _seckit_get_options(TRUE, FALSE);
+  }
+  else {
+    $options = _seckit_get_options();
+  }
+
+  // main description
+  $args['!browserscope'] = l(t('Browserscope'), 'http://www.browserscope.org/?category=security');
+  $form['seckit_description'] = array(
+    '#type' => 'item',
+    '#description' => t('This module provides your website with various options to mitigate risks of common web application vulnerabilities like Cross-site Scripting, Cross-site Request Forgery and Clickjacking. It also has some options to improve your SSL/TLS security and fixes Drupal 6 core Upload module issue leading to an easy exploitation of an old Internet Explorer MIME sniffer HTML injection vulnerability. Note that some security features are not supported by all browsers. You may find this out at !browserscope.', $args),
+  );
+
+  // main fieldset for XSS
+  $form['seckit_xss'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Cross-site Scripting'),
+    '#collapsible' => TRUE,
+    '#tree' => TRUE,
+    '#description' => t('Configure levels and various techniques of protection from cross-site scripting attacks'),
+  );
+
+  // fieldset for Content Security Policy (CSP)
+  $args['!wiki'] = l(t('Mozilla Wiki'), 'https://wiki.mozilla.org/Security/CSP');
+  $description = t('Content Security Policy is a policy framework that allows to specify trustworthy sources of content and to restrict its capabilities. You may read more about it at !wiki.', $args);
+  $form['seckit_xss']['csp'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Content Security Policy'),
+    '#collapsible' => TRUE,
+    '#tree' => TRUE,
+    '#description' => $description,
+  );
+  // CSP enable/disable
+  $form['seckit_xss']['csp']['checkbox'] = array(
+    '#type' => 'checkbox',
+    '#default_value' => $options['seckit_xss']['csp']['checkbox'],
+    '#title' => t('Send HTTP response header'),
+    '#return_value' => 1,
+    '#description' => t('Send Content-Security-Policy (official), X-Content-Security-Policy (supported by Mozilla Firefox and IE10) and X-WebKit-CSP (supported by Google Chrome and Safari) HTTP response headers with the list of Content Security Policy directives.'),
+  );
+  // CSP report-only mode
+  $form['seckit_xss']['csp']['report-only'] = array(
+    '#type' => 'checkbox',
+    '#default_value' => $options['seckit_xss']['csp']['report-only'],
+    '#title' => t('Report Only'),
+    '#return_value' => 1,
+    '#description' => t('Use Content Security Policy in report-only mode. In this case, violations of policies will only be reported, not blocked. Use this while configuring policies. Reports are logged to watchdog.'),
+  );
+  // CSP description
+  $items = array(
+    "'none' - block content from any source",
+    "'self' - allow content only from your domain",
+    "'unsafe-inline' - allow specific inline content (note, that it is supported by a subset of directives)",
+    "'unsafe-eval' - allow a set of string-to-code API which is restricted by default (supported by script-src directive)"
+  );
+  $args['!keywords'] = theme('item_list', array('items' => $items));
+  $items = array('* - load content from any source', '*.example.com - load content from example.com and all its subdomains', 'example.com:* - load content from example.com via any port.  Otherwise, it will use your website default port');
+  $args['!wildcards'] = theme('item_list', array('items' => $items));
+  $args['!spec'] = l(t('specification page'), 'http://www.w3.org/TR/CSP/');
+  $description = t("Set up security policy for different types of content. Don't use www prefix. Keywords are: !keywords Wildcards (*) are allowed: !wildcards More information is available at !spec.", $args);
+  $form['seckit_xss']['csp']['description'] = array(
+    '#type' => 'item',
+    '#title' => t('Directives'),
+    '#description' => $description,
+  );
+  // CSP default-src directive
+  $form['seckit_xss']['csp']['default-src'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['default-src'],
+    '#title' => 'default-src',
+    '#description' => t("Specify security policy for all types of content, which are not specified further (frame-ancestors excepted). Default is 'self'."),
+  );
+  // CSP script-src directive
+  $form['seckit_xss']['csp']['script-src'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['script-src'],
+    '#title' => 'script-src',
+    '#description' => t('Specify trustworthy sources for &lt;script&gt; elements.'),
+  );
+  // CSP object-src directive
+  $form['seckit_xss']['csp']['object-src'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['object-src'],
+    '#title' => 'object-src',
+    '#description' => t('Specify trustworthy sources for &lt;object&gt;, &lt;embed&gt; and &lt;applet&gt; elements.'),
+  );
+  // CSP style-src directive
+  $form['seckit_xss']['csp']['style-src'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['style-src'],
+    '#title' => 'style-src',
+    '#description' => t('Specify trustworthy sources for stylesheets. Note, that inline stylesheets and style attributes of HTML elements are allowed.'),
+  );
+  // CSP img-src directive
+  $form['seckit_xss']['csp']['img-src'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['img-src'],
+    '#title' => 'img-src',
+    '#description' => t('Specify trustworthy sources for &lt;img&gt; elements.'),
+  );
+  // CSP media-src directive
+  $form['seckit_xss']['csp']['media-src'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['media-src'],
+    '#title' => 'media-src',
+    '#description' => t('Specify trustworthy sources for &lt;audio&gt; and &lt;video&gt; elements.'),
+  );
+  // CSP frame-src directive
+  $form['seckit_xss']['csp']['frame-src'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['frame-src'],
+    '#title' => 'frame-src',
+    '#description' => t('Specify trustworthy sources for &lt;iframe&gt; and &lt;frame&gt; elements.'),
+  );
+  // CSP font-src directive
+  $form['seckit_xss']['csp']['font-src'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['font-src'],
+    '#title' => 'font-src',
+    '#description' => t('Specify trustworthy sources for @font-src CSS loads.'),
+  );
+  // CSP connect-src directive
+  $form['seckit_xss']['csp']['connect-src'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['connect-src'],
+    '#title' => 'connect-src',
+    '#description' => t('Specify trustworthy sources for XMLHttpRequest, WebSocket and EventSource connections.'),
+  );
+  // CSP report-uri directive
+  $form['seckit_xss']['csp']['report-uri'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['report-uri'],
+    '#title' => 'report-uri',
+    '#description' => t('Specify a URL (relative to the Drupal root) to which user-agents will report CSP violations. Use the default value, unless you have set up an alternative handler for these reports. Defaults to <code>admin/config/system/seckit/csp-report</code> which logs the report data in watchdog.'),
+  );
+  // CSP policy-uri directive
+  $form['seckit_xss']['csp']['policy-uri'] = array(
+    '#type' => 'textfield',
+    '#maxlength'=> 1024,
+    '#default_value' => $options['seckit_xss']['csp']['policy-uri'],
+    '#title' => 'policy-uri',
+    '#description' => t("Specify a URL (relative to the Drupal root) for a file containing the (entire) policy. <strong>All other directives will be omitted</strong> by Security Kit, as <code>policy-uri</code> may only be defined in the <em>absence</em> of other policy definitions in the <code>X-Content-Security-Policy</code> HTTP header. The MIME type for this URI <strong>must</strong> be <code>text/x-content-security-policy</code>, otherwise user-agents will enforce the policy <code>allow 'none'</code>  instead."),
+  );
+
+  // fieldset for X-XSS-Protection
+  $form['seckit_xss']['x_xss'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('X-XSS-Protection'),
+    '#collapsible' => TRUE,
+    '#tree' => TRUE,
+    '#description' => t('X-XSS-Protection HTTP response header controls Microsoft Internet Explorer, Google Chrome and Apple Safari internal XSS filters.'),
+  );
+  // options for X-XSS-Protection
+  $x_xss_protection_options = array(
+    SECKIT_X_XSS_DISABLE => t('Disabled'),
+    SECKIT_X_XSS_0 => '0',
+    SECKIT_X_XSS_1 => '1; mode=block',
+  );
+  // configure X-XSS-Protection
+  $link = l(t("IE's XSS filter security flaws in past"), 'http://hackademix.net/2009/11/21/ies-xss-filter-creates-xss-vulnerabilities');
+  $items = array('Disabled - XSS filter will work in default mode. Enabled by default', '0 - XSS filter will be disabled for a website. It may be useful because of ' . $link, '1; mode=block - XSS filter will be left enabled, but it will block entire page instead of modifying dangerous content');
+  $args['!values'] = theme('item_list', array('items' => $items));
+  $form['seckit_xss']['x_xss']['select'] = array(
+    '#type' => 'select',
+    '#title' => t('Configure'),
+    '#options' => $x_xss_protection_options,
+    '#default_value' => $options['seckit_xss']['x_xss']['select'],
+    '#description' => t('!values', $args),
+  );
+
+  // fieldset for X-Content-Type-Options
+  $args['!link'] = l(t('MSDN article'), 'http://blogs.msdn.com/b/ie/archive/2010/10/26/mime-handling-changes-in-internet-explorer.aspx');
+  $form['seckit_xss']['x_content_type'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('X-Content-Type-Options'),
+    '#collapsible' => TRUE,
+    '#tree' => TRUE,
+    '#description' => t('X-Content-Type-Options HTTP response header prevents browser from upsniffing content and serving files with inappropriate MIME type. More information is available at !link.', $args),
+  );
+  // enable/disable X-Content-Type-Options
+  $form['seckit_xss']['x_content_type']['checkbox'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Send HTTP response header'),
+    '#default_value' => $options['seckit_xss']['x_content_type']['checkbox'],
+    '#description' => t('Enable X-Content-Type-Options: nosniff HTTP response header.'),
+  );
+
+  // main fieldset for CSRF
+  $form['seckit_csrf'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Cross-site Request Forgery'),
+    '#tree' => TRUE,
+    '#collapsible' => TRUE,
+    '#description' => t('Configure levels and various techniques of protection from cross-site request forgery attacks'),
+  );
+
+  // enable/disable Origin
+  $form['seckit_csrf']['origin'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('HTTP Origin'),
+    '#default_value' => $options['seckit_csrf']['origin'],
+    '#description' => t('Check Origin HTTP request header.'),
+  );
+  // Origin whitelist
+  $description = t('Comma separated list of trustworthy sources. Do not enter your website URL - it is automatically added. Syntax of the source is: [protocol] :// [host] : [port] . E.g, http://example.com, https://example.com, https://www.example.com, http://www.example.com:8080');
+  $form['seckit_csrf']['origin_whitelist'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Allow requests from'),
+    '#default_value' => $options['seckit_csrf']['origin_whitelist'],
+    '#size' => 90,
+    '#description' => $description,
+  );
+
+  // main fieldset for Clickjacking
+  $form['seckit_clickjacking'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Clickjacking'),
+    '#collapsible' => TRUE,
+    '#tree' => TRUE,
+    '#description' => t('Configure levels and various techniques of protection from Clickjacking/UI Redressing attacks'),
+  );
+
+  // options for X-Frame-Options
+  $x_frame_options = array(
+    SECKIT_X_FRAME_DISABLE => t('Disabled'),
+    SECKIT_X_FRAME_SAMEORIGIN => 'SameOrigin',
+    SECKIT_X_FRAME_DENY => 'Deny',
+    SECKIT_X_FRAME_ALLOW_FROM => 'Allow-From',
+  );
+  // configure X-Frame-Options
+  $items = array('Disabled - turn off X-Frame-Options', 'SameOrigin - browser allows all the attempts of framing website within its domain. Enabled by default', 'Deny - browser rejects any attempt of framing website', 'Allow-From - browser allows framing website only from specified source');
+  $args['!values'] = theme('item_list', array('items' => $items));
+  $args['!msdn'] = l(t('MSDN article'), 'http://blogs.msdn.com/b/ie/archive/2009/01/27/ie8-security-part-vii-clickjacking-defenses.aspx');
+  $args['!spec'] = l(t('specification'), 'http://tools.ietf.org/html/draft-ietf-websec-x-frame-options-01');
+  $description = t("X-Frame-Options HTTP response header controls browser's policy of frame rendering. Possible values: !values You may read more about it at !msdn or !spec.", $args);
+  $form['seckit_clickjacking']['x_frame'] = array(
+    '#type' => 'select',
+    '#title' => t('X-Frame-Options'),
+    '#options' => $x_frame_options,
+    '#default_value' => $options['seckit_clickjacking']['x_frame'],
+    '#description' => $description,
+  );
+
+  // Origin value for "Allow-From" option.
+  $form['seckit_clickjacking']['x_frame_allow_from'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Allow-From'),
+    '#default_value' => implode("\n", $options['seckit_clickjacking']['x_frame_allow_from']),
+    '#description' => t('Origin URIs (as specified by RFC 6454) for the "X-Frame-Options: Allow-From" value. One per line. Example, http://domain.com'),
+  );
+
+  // enable/disable JS + CSS + Noscript protection
+  $args['!link'] = l(t('sirdarckcat'), 'http://www.sirdarckcat.net/');
+  $args['%js'] = t('seckit.document_write.js');
+  $args['%write'] = t('document.write()');
+  $args['%stop'] = t('stop SecKit protection');
+  $args['%css'] = t('seckit.no_body.css');
+  $args['%display'] = t('display: none');
+  $description = t('Enable protection via JavaScript, CSS and Noscript tag. This is the most efficient Clickjacking prevention technique. If webiste is not being framed, %js starts commenting with %write and stops when reaches %stop. Thus %css, which sets body display to none, is ignored. If particularly this JavaScript file is being blocked (with XSS filter of Internet Explorer 8 or Safari), %css sets %display to body. If JavaScript is disabled within browser, it shows a special message. Credits for this trick go to !link.', $args);
+  $form['seckit_clickjacking']['js_css_noscript'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable JavaScript + CSS + Noscript protection'),
+    '#return_value' => 1,
+    '#default_value' => $options['seckit_clickjacking']['js_css_noscript'],
+    '#description' => $description,
+  );
+
+  // custom text for "disabled JavaScript" message
+  $form['seckit_clickjacking']['noscript_message'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Custom text for disabled JavaScript message'),
+    '#default_value' => $options['seckit_clickjacking']['noscript_message'],
+    '#description' => t('This message will be shown to user when JavaScript is disabled or unsupported in his browser. Default is "Sorry, you need to enable JavaScript to visit this website."'),
+  );
+
+  // main fieldset for SSL/TLS
+  $form['seckit_ssl'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('SSL/TLS'),
+    '#collapsible' => TRUE,
+    '#tree' => TRUE,
+    '#description' => t('Configure various techniques to improve security of SSL/TLS'),
+  );
+
+  // enable/disable HTTP Strict Transport Security (HSTS)
+  $args['!wiki'] = l(t('Wikipedia'), 'http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security');
+  $form['seckit_ssl']['hsts'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('HTTP Strict Transport Security'),
+    '#description' => t('Enable Strict-Transport-Security HTTP response header. HTTP Strict Transport Security (HSTS) header is proposed to prevent eavesdropping and man-in-the-middle attacks like SSLStrip, when a single non-HTTPS request is enough for credential theft or hijacking. It forces browser to connect to the server in HTTPS-mode only and automatically convert HTTP links into secure before sending request. !wiki has more information about HSTS', $args),
+    '#default_value' => $options['seckit_ssl']['hsts'],
+    '#return_value' => 1,
+  );
+  // HSTS max-age directive
+  $form['seckit_ssl']['hsts_max_age'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Max-Age'),
+    '#description' => t('Specify Max-Age value in seconds. It sets period when user-agent should remember receipt of this header field from this server. Default is 1000.'),
+    '#default_value' => $options['seckit_ssl']['hsts_max_age'],
+  );
+  // STS includeSubDomains directive
+  $form['seckit_ssl']['hsts_subdomains'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Include Subdomains'),
+    '#description' => t('Force HTTP Strict Transport Security for all subdomains. If enabled, HSTS policy will be applied for all subdomains, otherwise only for the main domain.'),
+    '#return_value' => 1,
+    '#default_value' => $options['seckit_ssl']['hsts_subdomains'],
+  );
+
+  // main fieldset for various
+  $form['seckit_various'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Various'),
+    '#collapsible' => TRUE,
+    '#tree' => TRUE,
+    '#description' => t('Configure various unsorted security enhancements'),
+  );
+
+  // enable/disable From-Origin
+  $args['!spec'] = l(t('specification'), 'http://www.w3.org/TR/from-origin/');
+  $form['seckit_various']['from_origin'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('From-Origin'),
+    '#default_value' => $options['seckit_various']['from_origin'],
+    '#description' => t('Enable From-Origin HTTP response header. This forces user-agent to retrieve embedded content from your site only to listed destination. More information is available at !spec page.', $args),
+  );
+  // From-Origin destination
+  $items = array('same - allow loading of content only from your site. Default value.', 'serialized origin - address of trustworthy destination. For example, http://example.com, https://example.com, https://www.example.com, http://www.example.com:8080');
+  $args['!items'] = theme('item_list', array('items' => $items));
+  $form['seckit_various']['from_origin_destination'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Allow loading content to'),
+    '#default_value' => $options['seckit_various']['from_origin_destination'],
+    '#size' => 90,
+    '#description' => t('Trustworthy destination. Possible variants are: !items', $args),
+  );
+
+  // Execute the default handlers first.
+  $form = system_settings_form($form);
+
+  // Run custom validation and submission handlers afterwards.
+  $form['#validate'][] = 'seckit_admin_form_validate';
+  $form['#submit'][] = 'seckit_admin_form_submit';
+
+  return $form;
+}
+
+/**
+ * Validates form data.
+ */
+function seckit_admin_form_validate($form, &$form_state) {
+  // if From-Origin is enabled, it should be explicitly set
+  $from_origin_enable = $form_state['values']['seckit_various']['from_origin'];
+  $from_origin_destination = $form_state['values']['seckit_various']['from_origin_destination'];
+  if (($from_origin_enable == 1) && (!$from_origin_destination)) {
+    form_error($form['seckit_various']['from_origin_destination'], t('You have to set up trustworthy destination for From-Origin HTTP response header. Default is same.'));
+  }
+  // if X-Frame-Options is set to Allow-From, it should be explicitly set
+  $x_frame_value = $form_state['values']['seckit_clickjacking']['x_frame'];
+  if ($x_frame_value == SECKIT_X_FRAME_ALLOW_FROM) {
+    $x_frame_allow_from = $form_state['values']['seckit_clickjacking']['x_frame_allow_from'];
+    if (!_seckit_explode_value($x_frame_allow_from)) {
+      form_error($form['seckit_clickjacking']['x_frame_allow_from'], t('You must specify a trusted Origin for the Allow-From value of the X-Frame-Options HTTP response header.'));
+    }
+  }
+  // if HTTP Strict Transport Security is enabled, max-age must be specified.
+  // HSTS max-age should only contain digits.
+  $hsts_enable = $form_state['values']['seckit_ssl']['hsts'];
+  $hsts_max_age = $form_state['values']['seckit_ssl']['hsts_max_age'];
+  if (($hsts_enable == 1) && (!$hsts_max_age)) {
+    form_error($form['seckit_ssl']['hsts_max_age'], t('You have to set up Max-Age value for HTTP Strict Transport Security. Default is 1000.'));
+  }
+  if (preg_match('/[^0-9]/', $hsts_max_age)) {
+    form_error($form['seckit_ssl']['hsts_max_age'], t('Only digits are allowed in HTTP Strict Transport Security Max-Age field.'));
+  }
+  // if JS + CSS + Noscript Clickjacking protection is enabled,
+  // custom text for disabled JS must be specified
+  $js_css_noscript_enable = $form_state['values']['seckit_clickjacking']['js_css_noscript'];
+  $noscript_message = $form_state['values']['seckit_clickjacking']['noscript_message'];
+  if (($js_css_noscript_enable == 1) && (!$noscript_message)) {
+    form_error($form['seckit_clickjacking']['noscript_message'], t('You have to set up Custom text for disabled JavaScript message when JS + CSS + Noscript protection is enabled.'));
+  }
+}
+
+/**
+ * Submits form.
+ */
+function seckit_admin_form_submit($form, &$form_state) {
+  $from_origin_enable = $form_state['values']['seckit_various']['from_origin'];
+  $x_content_type_options_enable = $form_state['values']['seckit_xss']['x_content_type']['checkbox'];
+  $file_system = file_default_scheme();
+  if ($from_origin_enable && ($file_system == 'public')) {
+    $msg = 'From-Origin HTTP response header will not be served for files because of public file system. It is recommended to enable private file system to ensure provided by From-Origin security.';
+    drupal_set_message($msg, 'warning');
+  }
+  if ($x_content_type_options_enable && ($file_system == 'public')) {
+    $msg = 'X-Content-Type-Options HTTP response header will not be served for files because of public file system. It is recommended to enable private file system to ensure provided by X-Content-Type-Options security.';
+    drupal_set_message($msg, 'warning');
+  }
+
+  // Our depencency on seckit_boot() may have changed, so reset the
+  // bootstrap module settings and cache.
+  _system_update_bootstrap_status();
+}

--- a/docroot/sites/all/modules/contrib/seckit/js/seckit.document_write.js
+++ b/docroot/sites/all/modules/contrib/seckit/js/seckit.document_write.js
@@ -1,0 +1,7 @@
+/**
+ * If site is not being framed or being framed within the same host,
+ * start commenting out seckit.no_body.css.
+ */
+if (top === self || top.location.hostname === self.location.hostname) {
+  document.write('<!--');
+}

--- a/docroot/sites/all/modules/contrib/seckit/js/seckit.listener.js
+++ b/docroot/sites/all/modules/contrib/seckit/js/seckit.listener.js
@@ -1,0 +1,176 @@
+Drupal.behaviors.seckit = {
+  attach: function(context) {
+    seckit_listener_hsts(context);
+    seckit_listener_csp(context);
+    seckit_listener_origin(context);
+    seckit_listener_clickjacking_x_frame(context);
+    seckit_listener_clickjacking_noscript(context);
+    seckit_listener_various(context);
+    (function ($) {
+      $('#edit-seckit-ssl-hsts', context).click(function () {
+        seckit_listener_hsts(context);
+      });
+      $('#edit-seckit-xss-csp-checkbox', context).click(function () {
+        seckit_listener_csp(context);
+      });
+      $('#edit-seckit-xss-csp-policy-uri', context).blur(function () {
+        seckit_listener_csp(context);
+      });
+      $('#edit-seckit-csrf-origin', context).click(function () {
+        seckit_listener_origin(context);
+      });
+      $('#edit-seckit-clickjacking-x-frame', context).change(function () {
+        seckit_listener_clickjacking_x_frame(context);
+      });
+      $('#edit-seckit-clickjacking-js-css-noscript', context).click(function () {
+        seckit_listener_clickjacking_noscript(context);
+      });
+      $('#edit-seckit-various-from-origin', context).click(function () {
+        seckit_listener_various(context);
+      });
+    })(jQuery);
+  }
+};
+
+/**
+ * Adds/removes attributes for input fields in
+ * SSL/TLS fieldset for HTTP Strict Transport Security.
+ */
+function seckit_listener_hsts(context) {
+  (function ($) {
+    if ($('#edit-seckit-ssl-hsts').is(':checked')) {
+      $('#edit-seckit-ssl-hsts-max-age', context).removeAttr('disabled');
+      $('#edit-seckit-ssl-hsts-subdomains', context).removeAttr('disabled');
+      $('label[for="edit-seckit-ssl-hsts-max-age"]', context).append('<span title="' + Drupal.t('This field is required.') + '" class="form-required">*</span>');
+    }
+    else {
+      $('#edit-seckit-ssl-hsts-max-age', context).attr('disabled', 'disabled');
+      $('#edit-seckit-ssl-hsts-subdomains', context).attr('disabled', 'disabled');
+      $('label[for="edit-seckit-ssl-hsts-max-age"] > span', context).remove();
+    }
+  })(jQuery);
+}
+
+/**
+ * Adds/removes attributes for input fields in
+ * Content Security Policy fieldset.
+ */
+function seckit_listener_csp(context) {
+  (function ($) {
+    var checkbox_status = $('#edit-seckit-xss-csp-checkbox').is(':checked');
+    var policy_uri_status = $('#edit-seckit-xss-csp-policy-uri').val().length === 0;
+    if (checkbox_status) {
+      $('#edit-seckit-xss-csp-report-only', context).removeAttr('disabled');
+      $('#edit-seckit-xss-csp-policy-uri', context).removeAttr('disabled');
+      if (!policy_uri_status) {
+        _seckit_csp_add_attributes(context);
+      }
+      else {
+        _seckit_csp_remove_attributes(context);
+      }
+    }
+    else {
+      $('#edit-seckit-xss-csp-report-only', context).attr('disabled', 'disabled');
+      $('#edit-seckit-xss-csp-policy-uri', context).attr('disabled', 'disabled');
+      _seckit_csp_add_attributes(context);
+    }
+  })(jQuery);
+}
+
+/**
+ * Removes attributes for CSP input fields.
+ */
+function _seckit_csp_remove_attributes(context) {
+  (function ($) {
+    $('#edit-seckit-xss-csp-default-src', context).removeAttr('disabled');
+    $('#edit-seckit-xss-csp-script-src', context).removeAttr('disabled');
+    $('#edit-seckit-xss-csp-object-src', context).removeAttr('disabled');
+    $('#edit-seckit-xss-csp-style-src', context).removeAttr('disabled');
+    $('#edit-seckit-xss-csp-img-src', context).removeAttr('disabled');
+    $('#edit-seckit-xss-csp-media-src', context).removeAttr('disabled');
+    $('#edit-seckit-xss-csp-frame-src', context).removeAttr('disabled');
+    $('#edit-seckit-xss-csp-font-src', context).removeAttr('disabled');
+    $('#edit-seckit-xss-csp-connect-src', context).removeAttr('disabled');
+    $('#edit-seckit-xss-csp-report-uri', context).removeAttr('disabled');
+  })(jQuery);
+}
+
+/**
+ * Adds attributes for CSP input fields.
+ */
+function _seckit_csp_add_attributes(context) {
+  (function ($) {
+    $('#edit-seckit-xss-csp-default-src', context).attr('disabled', 'disabled');
+    $('#edit-seckit-xss-csp-script-src', context).attr('disabled', 'disabled');
+    $('#edit-seckit-xss-csp-object-src', context).attr('disabled', 'disabled');
+    $('#edit-seckit-xss-csp-style-src', context).attr('disabled', 'disabled');
+    $('#edit-seckit-xss-csp-img-src', context).attr('disabled', 'disabled');
+    $('#edit-seckit-xss-csp-media-src', context).attr('disabled', 'disabled');
+    $('#edit-seckit-xss-csp-frame-src', context).attr('disabled', 'disabled');
+    $('#edit-seckit-xss-csp-font-src', context).attr('disabled', 'disabled');
+    $('#edit-seckit-xss-csp-connect-src', context).attr('disabled', 'disabled');
+    $('#edit-seckit-xss-csp-report-uri', context).attr('disabled', 'disabled');
+  })(jQuery);
+}
+
+/**
+ * Adds/removes attributes for input fields in
+ * Cross-site Request Forgery fieldset for HTTP Origin.
+ */
+function seckit_listener_origin(context) {
+  (function ($) {
+    if ($('#edit-seckit-csrf-origin').is(':checked')) {
+      $('#edit-seckit-csrf-origin-whitelist', context).removeAttr('disabled');
+    }
+    else {
+      $('#edit-seckit-csrf-origin-whitelist', context).attr('disabled', 'disabled');
+    }
+  })(jQuery);
+}
+
+/**
+ * Adds/removes attributes for input fields in
+ * Clickjacking "X-Frame-Options" fields.
+ */
+function seckit_listener_clickjacking_x_frame(context) {
+  (function ($) {
+    if ($('#edit-seckit-clickjacking-x-frame').find(":selected").text() == 'Allow-From') {
+      $('#edit-seckit-clickjacking-x-frame-allow-from', context).removeAttr('disabled');
+      $('label[for="edit-seckit-clickjacking-x-frame-allow-from"]', context).append('<span title="' + Drupal.t('This field is required.') + '" class="form-required">*</span>');
+    }
+    else {
+      $('#edit-seckit-clickjacking-x-frame-allow-from', context).attr('disabled', 'disabled');
+      $('label[for="edit-seckit-clickjacking-x-frame-allow-from"] > span', context).remove();
+    }
+  })(jQuery);
+}
+
+/**
+ * Adds/removes attributes for input fields in
+ * Clickjacking NoScript fields.
+ */
+function seckit_listener_clickjacking_noscript(context) {
+  (function ($) {
+    if ($('#edit-seckit-clickjacking-js-css-noscript').is(':checked')) {
+      $('#edit-seckit-clickjacking-noscript-message', context).removeAttr('disabled');
+    }
+    else {
+      $('#edit-seckit-clickjacking-noscript-message', context).attr('disabled', 'disabled');
+    }
+  })(jQuery);
+}
+
+/**
+ * Adds/removes attributes for input fields in
+ * Various fieldset.
+ */
+function seckit_listener_various(context) {
+  (function ($) {
+    if ($('#edit-seckit-various-from-origin').is(':checked')) {
+      $('#edit-seckit-various-from-origin-destination', context).removeAttr('disabled');
+    }
+    else {
+      $('#edit-seckit-various-from-origin-destination', context).attr('disabled', 'disabled');
+    }
+  })(jQuery);
+}

--- a/docroot/sites/all/modules/contrib/seckit/seckit.api.php
+++ b/docroot/sites/all/modules/contrib/seckit/seckit.api.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by Security Kit.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Alter the Security Kit settings.
+ *
+ * @param array $options
+ *   Array of runtime options.
+ *
+ * @see _seckit_get_options().
+ */
+function hook_seckit_options_alter(&$options) {
+  $options['seckit_clickjacking']['x_frame'] = SECKIT_X_FRAME_SAMEORIGIN;
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/docroot/sites/all/modules/contrib/seckit/seckit.info
+++ b/docroot/sites/all/modules/contrib/seckit/seckit.info
@@ -1,0 +1,16 @@
+name = Security Kit
+description = "Enhance security of your Drupal website."
+package = Security
+core = 7.x
+configure = admin/config/system/seckit
+files[] = seckit.install
+files[] = seckit.module
+files[] = seckit.test
+files[] = includes/seckit.form.inc
+
+; Information added by Drupal.org packaging script on 2014-05-06
+version = "7.x-1.9"
+core = "7.x"
+project = "seckit"
+datestamp = "1399337028"
+

--- a/docroot/sites/all/modules/contrib/seckit/seckit.install
+++ b/docroot/sites/all/modules/contrib/seckit/seckit.install
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @file
+ * Install/update/uninstall actions for SecKit.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function seckit_uninstall() {
+  variable_del('seckit_xss');
+  variable_del('seckit_csrf');
+  variable_del('seckit_clickjacking');
+  variable_del('seckit_ssl');
+  variable_del('seckit_various');
+}
+
+/**
+ * Implements hook_requirements().
+ */
+function seckit_requirements($phase) {
+  $requirements = array();
+  // Ensure translations don't break during installation.
+  $t = get_t();
+
+  if ($phase == 'runtime') {
+    $options = _seckit_get_options();
+    $csp_options = $options['seckit_xss']['csp'];
+
+    if ($csp_options['report-only']) {
+      $requirements['seckit'] = array(
+        'title' => $t('Security Kit'),
+        'value' => $t("Content Security Policy (CSP) is in 'report only' mode. Policy violations will <em>not</em> be blocked. !configure.", array('!configure' => l('Configure Security Kit', 'admin/config/system/seckit'))),
+        'severity' => REQUIREMENT_WARNING,
+      );
+    }
+  }
+
+  return $requirements;
+}
+
+/**
+ * Changes Content-Security-Policy "allow" directive to "default-src".
+ */
+function seckit_update_7101() {
+  // update CSP directives
+  // default-src is used instead of allow
+  $options = variable_get('seckit_xss');
+  if (isset($options['csp']['allow'])) {
+    $directive = $options['csp']['allow'];
+    if ($directive) {
+      // remove allow
+      unset($options['csp']['allow']);
+      // add default-src
+      $options['csp']['default-src'] = $directive;
+      // delete and set new version of variable
+      variable_del('seckit_xss');
+      variable_set('seckit_xss', $options);
+    }
+  }
+}
+
+/**
+ * Removes "Override style for frames" options.
+ *
+ * http://drupal.org/node/1243032
+ */
+function seckit_update_7102() {
+  // removes override style variable
+  $options = variable_get('seckit_clickjacking');
+  // remove override style
+  unset($options['override_style']);
+  // delete and set new version
+  variable_del('seckit_clickjacking');
+  variable_set('seckit_clickjacking', $options);
+}
+
+/**
+ * Changes Content-Security-Policy "xhr-src" directive to "connect-src".
+ *
+ * http://drupal.org/node/1241226#comment-5125336
+ */
+function seckit_update_7103() {
+  // update CSP directives
+  // connect-src is used instead of xhr-src
+  $options = variable_get('seckit_xss');
+  // add connect-src
+  $options['csp']['connect-src'] = $options['csp']['xhr-src'];;
+  // remove xhr-src
+  unset($options['csp']['xhr-src']);
+  // delete and set new version of variable
+  variable_del('seckit_xss');
+  variable_set('seckit_xss', $options);
+}
+
+
+/**
+ * Removes Content-Security-Policy "frame-ancestors" directive and "options".
+ *
+ * They are removed from stable version of specification http://www.w3.org/TR/CSP.
+ */
+function seckit_update_7104() {
+  // update CSP directives
+  $options = variable_get('seckit_xss');
+  // frame-ancestors is removed
+  unset($options['csp']['frame-ancestors']);
+  // options is removed
+  unset($options['csp']['options']);
+  // delete and set new version of variable
+  variable_del('seckit_xss');
+  variable_set('seckit_xss', $options);
+}

--- a/docroot/sites/all/modules/contrib/seckit/seckit.module
+++ b/docroot/sites/all/modules/contrib/seckit/seckit.module
@@ -1,0 +1,593 @@
+<?php
+/**
+ * @file
+ * Allows administrators to improve security of the website.
+ */
+
+/**
+ * Necessary constants.
+ */
+define('SECKIT_X_XSS_DISABLE', 0); // disable X-XSS-Protection HTTP header
+define('SECKIT_X_XSS_0', 1); // set X-XSS-Protection HTTP header to 0
+define('SECKIT_X_XSS_1', 2); // set X-XSS-Protection HTTP header to 1; mode=block
+define('SECKIT_X_FRAME_DISABLE', 0); // disable X-Frame-Options HTTP header
+define('SECKIT_X_FRAME_SAMEORIGIN', 1); // set X-Frame-Options HTTP header to SameOrigin
+define('SECKIT_X_FRAME_DENY', 2); // set X-Frame-Options HTTP header to Deny
+define('SECKIT_X_FRAME_ALLOW_FROM', 3); // set X-Frame-Options HTTP header to Allow-From
+
+/**
+ * Implements hook_permission().
+ */
+function seckit_permission() {
+  return array(
+    'administer seckit' => array(
+      'title' => t('Administer SecKit'),
+      'description' => t('Configure security features of your Drupal installation.'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_menu().
+ */
+function seckit_menu() {
+  // settings page
+  $items['admin/config/system/seckit'] = array(
+    'title'            => 'Security Kit',
+    'page callback'    => 'drupal_get_form',
+    'page arguments'   => array('seckit_admin_form'),
+    'description'      => 'Configure various options to improve security of your website.',
+    'access arguments' => array('administer seckit'),
+    'file'             => 'includes/seckit.form.inc',
+  );
+  // menu callback for CSP reporting
+  $items['admin/config/system/seckit/csp-report'] = array(
+    'page callback'   => '_seckit_csp_report',
+    'access callback' => TRUE,
+    'type'            => MENU_CALLBACK,
+  );
+  return $items;
+}
+
+/**
+ * Implements hook_init().
+ */
+function seckit_init() {
+  // get default/set options
+  $options = _seckit_get_options();
+
+  // execute necessary functions
+  if ($options['seckit_csrf']['origin']) {
+    _seckit_origin();
+  }
+  if ($options['seckit_xss']['csp']['checkbox']) {
+    _seckit_csp();
+  }
+  if ($options['seckit_xss']['x_xss']['select']) {
+    _seckit_x_xss($options['seckit_xss']['x_xss']['select']);
+  }
+  if ($options['seckit_xss']['x_content_type']['checkbox']) {
+    _seckit_x_content_type_options();
+  }
+  if ($options['seckit_clickjacking']['x_frame']) {
+    _seckit_x_frame($options['seckit_clickjacking']['x_frame']);
+  }
+  if ($options['seckit_clickjacking']['js_css_noscript']) {
+    _seckit_js_css_noscript();
+  }
+  if ($options['seckit_ssl']['hsts']) {
+    _seckit_hsts();
+  }
+  if ($options['seckit_various']['from_origin']) {
+    _seckit_from_origin();
+  }
+
+  // load jQuery listener
+  if ($_GET['q'] == 'admin/config/system/seckit') {
+    $path = drupal_get_path('module', 'seckit');
+    $listener = "$path/js/seckit.listener.js";
+    drupal_add_js($listener);
+  }
+}
+
+/**
+ * Implements hook_boot().
+ *
+ * When multiple 'Allow-From' values are configured for X-Frame-Options,
+ * we dynamically set the header so that it is correct even when pages are
+ * served from the page cache.
+ *
+ * In other circumstances, Drupal does not see this implementation.
+ * @see seckit_module_implements_alter().
+ */
+function seckit_boot() {
+  $options = _seckit_get_options();
+  if ($options['seckit_clickjacking']['x_frame'] != SECKIT_X_FRAME_ALLOW_FROM) {
+    return;
+  }
+
+  // If this request's Origin is allowed, we specify that value.
+  // If the origin is not allowed, we can use any other value to prevent
+  // the client from framing the page.
+  $allowed = $options['seckit_clickjacking']['x_frame_allow_from'];
+  $origin = !empty($_SERVER['HTTP_ORIGIN']) ? $_SERVER['HTTP_ORIGIN'] : '';
+  if (!in_array($origin, $allowed, TRUE)) {
+    $origin = array_pop($allowed);
+  }
+
+  drupal_add_http_header('X-Frame-Options', "Allow-From: $origin");
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ *
+ * The 'Allow-From' field of X-Frame-Options supports a single origin only.
+ * http://tools.ietf.org/html/rfc7034#section-2.3.2.3
+ *
+ * Consequently, when multiple values are configured we must resort to
+ * hook_boot() to dynamically set the header to the Origin of the current
+ * request, if that is one of the allowed values.
+ *
+ * Conversely, when we do not require hook_boot(), we unset our
+ * implementation, preventing _system_update_bootstrap_status() from
+ * registering it, and anything from invoking it.
+ *
+ * @see seckit_admin_form_submit().
+ */
+function seckit_module_implements_alter(&$implementations, $hook) {
+  if ($hook != 'boot') {
+    return;
+  }
+
+  $options = _seckit_get_options(TRUE);
+  if ($options['seckit_clickjacking']['x_frame'] != SECKIT_X_FRAME_ALLOW_FROM
+    || count($options['seckit_clickjacking']['x_frame_allow_from']) <= 1)
+  {
+    // seckit_boot() is not needed.
+    unset($implementations['seckit']);
+    // In this case, _seckit_x_frame() will generate the header
+    // (which will be cacheable), if it is required.
+  }
+}
+
+/**
+ * Sends Content Security Policy HTTP headers.
+ *
+ * Header specifies Content Security Policy (CSP) for a website,
+ * which is used to allow/block content from selected sources.
+ *
+ * Based on specification available at http://www.w3.org/TR/CSP/
+ */
+function _seckit_csp() {
+  // get default/set options
+  $options         = _seckit_get_options();
+  $options         = $options['seckit_xss']['csp'];
+  $csp_report_only = $options['report-only'];
+  $csp_default_src = $options['default-src'];
+  $csp_script_src  = $options['script-src'];
+  $csp_object_src  = $options['object-src'];
+  $csp_img_src     = $options['img-src'];
+  $csp_media_src   = $options['media-src'];
+  $csp_style_src   = $options['style-src'];
+  $csp_frame_src   = $options['frame-src'];
+  $csp_font_src    = $options['font-src'];
+  $csp_connect_src = $options['connect-src'];
+  $csp_report_uri  = $options['report-uri'];
+  $csp_policy_uri  = $options['policy-uri'];
+
+  // prepare directives
+  $directives = array();
+
+  // if policy-uri is declared, no other directives are permitted.
+  if ($csp_policy_uri) {
+    $directives = "policy-uri " . base_path() . $csp_policy_uri;
+  }
+  // otherwise prepare directives
+  else {
+    if ($csp_default_src) {
+      $directives[] = "default-src $csp_default_src";
+    }
+    if ($csp_script_src) {
+      $directives[] = "script-src $csp_script_src";
+    }
+    if ($csp_object_src) {
+      $directives[] = "object-src $csp_object_src";
+    }
+    if ($csp_style_src) {
+      $directives[] = "style-src $csp_style_src";
+    }
+    if ($csp_img_src) {
+      $directives[] = "img-src $csp_img_src";
+    }
+    if ($csp_media_src) {
+      $directives[] = "media-src $csp_media_src";
+    }
+    if ($csp_frame_src) {
+      $directives[] = "frame-src $csp_frame_src";
+    }
+    if ($csp_font_src) {
+      $directives[] = "font-src $csp_font_src";
+    }
+    if ($csp_connect_src) {
+      $directives[] = "connect-src $csp_connect_src";
+    }
+    if ($csp_report_uri) {
+      $directives[] = "report-uri " . base_path() . $csp_report_uri;
+    }
+    // merge directives
+    $directives = implode('; ', $directives);
+  }
+
+  // send HTTP response header if directives were prepared
+  if ($directives) {
+    if ($csp_report_only) {
+      // use report-only mode
+      drupal_add_http_header('Content-Security-Policy-Report-Only', $directives); // official name
+      drupal_add_http_header('X-Content-Security-Policy-Report-Only', $directives); // Firefox and IE10
+      drupal_add_http_header('X-WebKit-CSP-Report-Only', $directives); // Chrome and Safari
+    }
+    else {
+      drupal_add_http_header('Content-Security-Policy', $directives); // official name
+      drupal_add_http_header('X-Content-Security-Policy', $directives); // Firefox and IE10
+      drupal_add_http_header('X-WebKit-CSP', $directives); // Chrome and Safari
+    }
+  }
+}
+
+/**
+ * Reports CSP violations to watchdog.
+ */
+function _seckit_csp_report() {
+  // Only allow POST data with Content-Type application/csp-report
+  // or application/json (the latter to support older user agents).
+  // n.b. The CSP spec (1.0, 1.1) mandates this Content-Type header/value.
+  // n.b. Content-Length is optional, so we don't check it.
+  if (empty($_SERVER['CONTENT_TYPE']) || empty($_SERVER['REQUEST_METHOD'])) {
+    return;
+  }
+  if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    return;
+  }
+  $pattern = '~^application/(csp-report|json)\h*(;|$)~';
+  if (!preg_match($pattern, $_SERVER['CONTENT_TYPE'])) {
+    return;
+  }
+
+  // Get and parse report.
+  $reports = file_get_contents('php://input');
+  $reports = json_decode($reports);
+  if (!is_object($reports)) {
+    return;
+  }
+
+  // Log the report data to watchdog.
+  foreach ($reports as $report) {
+    if (!isset($report->{'violated-directive'})) {
+      continue;
+    }
+    $info = array(
+      '@directive'   => $report->{'violated-directive'},
+      '@blocked_uri' => $report->{'blocked-uri'},
+      '@data'        => print_r($report, TRUE),
+    );
+    watchdog('seckit', 'CSP: Directive @directive violated.<br /> Blocked URI: @blocked_uri.<br /> <pre>Data: @data</pre>', $info, WATCHDOG_WARNING);
+  }
+}
+
+/**
+ * Sends X-XSS-Protection HTTP header.
+ *
+ * X-XSS-Protection controls IE8/Safari/Chrome internal XSS filter.
+ */
+function _seckit_x_xss($setting) {
+  switch ($setting) {
+    case SECKIT_X_XSS_0:
+      drupal_add_http_header('X-XSS-Protection', '0'); // set X-XSS-Protection header to 0
+      break;
+
+    case SECKIT_X_XSS_1:
+      drupal_add_http_header('X-XSS-Protection', '1; mode=block'); // set X-XSS-Protection header to 1; mode=block
+      break;
+
+    case SECKIT_X_XSS_DISABLE:
+    default: // do nothing
+      break;
+  }
+}
+
+/**
+ * Sends X-Content-Type-Options HTTP response header.
+ */
+function _seckit_x_content_type_options() {
+  drupal_add_http_header('X-Content-Type-Options', 'nosniff');
+}
+
+/**
+ * Aborts HTTP request upon invalid 'Origin' HTTP request header.
+ *
+ * When included in an HTTP request, the Origin header indicates the origin(s)
+ * that caused the user agent to issue the request. This helps to protect
+ * against CSRF attacks, as we can abort requests with an unapproved origin.
+ *
+ * Applies to all HTTP request methods except GET and HEAD.
+ *
+ * Requests which do not include an 'Origin' header must always be allowed,
+ * as (a) not all user-agents support the header, and (b) those that do may
+ * include it or omit it at their discretion.
+ *
+ * Note that (a) will become progressively less of a factor over time --
+ * CSRF attacks depend upon convincing a user agent to send a request, and
+ * there is no particular motivation for users to prevent their web browsers
+ * from sending this header; so as people upgrade to browsers which support
+ * 'Origin', its effectiveness increases.
+ *
+ * Implementation of Origin is based on specification draft available at
+ * http://tools.ietf.org/html/draft-abarth-origin-09
+ */
+function _seckit_origin() {
+  // Allow requests without an 'Origin' header, or with a 'null' origin.
+  $origin = isset($_SERVER['HTTP_ORIGIN']) ? $_SERVER['HTTP_ORIGIN'] : '';
+  if (!$origin || $origin === 'null') {
+    return;
+  }
+  // Allow command-line requests.
+  // TODO: Should this test be in seckit_init() ?
+  // (i.e. Should this module do *anything* in the case of cli requests?)
+  if (drupal_is_cli()) {
+    return;
+  }
+  // Allow GET and HEAD requests.
+  $method = $_SERVER['REQUEST_METHOD'];
+  if (in_array($method, array('GET', 'HEAD'), TRUE)) {
+    return;
+  }
+  // Allow requests from localhost.
+  if (in_array(ip_address(), array('localhost', '127.0.0.1', '::1'), TRUE)) {
+    return;
+  }
+
+  // Allow requests from whitelisted Origins.
+  global $base_root;
+  $options = _seckit_get_options();
+  $whitelist = explode(',', $options['seckit_csrf']['origin_whitelist']);
+  $whitelist[] = $base_root; // default origin is always allowed
+  if (in_array($origin, $whitelist, TRUE)) {
+    return;
+  }
+
+  // The Origin is invalid, so we deny the request.
+  // Clean the POST data first, as drupal_access_denied() may render a page
+  // with forms which check for their submissions.
+  $_POST = array();
+  drupal_access_denied(); // send 403 response and show Access Denied page
+  $args = array(
+    '@ip'     => ip_address(),
+    '@origin' => $origin,
+  );
+  watchdog('seckit', 'Possible CSRF attack was blocked. IP address: @ip, Origin: @origin.', $args, WATCHDOG_WARNING);
+  drupal_exit(); // abort request
+}
+
+/**
+ * Sends X-Frame-Options HTTP header.
+ *
+ * X-Frame-Options controls should browser show frames or not.
+ * More information can be found at initial article about it at
+ * http://blogs.msdn.com/ie/archive/2009/01/27/ie8-security-part-vii-clickjacking-defenses.aspx
+ *
+ * Implementation of X-Frame-Options is based on specification draft availabe at
+ * http://tools.ietf.org/html/draft-ietf-websec-x-frame-options-01
+ */
+function _seckit_x_frame($setting) {
+  switch ($setting) {
+    case SECKIT_X_FRAME_SAMEORIGIN:
+      drupal_add_http_header('X-Frame-Options', 'SameOrigin'); // set X-Frame-Options to SameOrigin
+      break;
+
+    case SECKIT_X_FRAME_DENY:
+      drupal_add_http_header('X-Frame-Options', 'Deny'); // set X-Frame-Options to Deny
+      break;
+
+    case SECKIT_X_FRAME_ALLOW_FROM:
+      $options = _seckit_get_options();
+      $allowed = $options['seckit_clickjacking']['x_frame_allow_from'];
+      if (count($allowed) == 1) {
+        $value = array_pop($allowed);
+        drupal_add_http_header('X-Frame-Options', "Allow-From: $value");
+      }
+      // If there were multiple values, then seckit_boot() took care of it.
+      break;
+
+    case SECKIT_X_FRAME_DISABLE:
+    default: // do nothing
+      break;
+  }
+}
+
+/**
+ * Enables JavaScript + CSS + Noscript Clickjacking defense.
+ *
+ * Closes inline JavaScript and allows loading of any inline HTML elements.
+ * After, it starts new inline JavaScript to avoid breaking syntax.
+ * We need it, because Drupal API doesn't allow to init HTML elements in desired sequence.
+ */
+function _seckit_js_css_noscript() {
+  drupal_add_js(_seckit_get_js_css_noscript_code(), array('type' => 'inline'));
+}
+
+/**
+ * Gets JavaScript and CSS code.
+ *
+ * @return string
+ */
+function _seckit_get_js_css_noscript_code() {
+  $options = _seckit_get_options();
+  $message = filter_xss($options['seckit_clickjacking']['noscript_message']);
+  $path = base_path() . drupal_get_path('module', 'seckit');
+  return <<< EOT
+      // close script tag for SecKit protection
+      //--><!]]>
+      </script>
+      <script type="text/javascript" src="$path/js/seckit.document_write.js"></script>
+      <link type="text/css" rel="stylesheet" id="seckit-clickjacking-no-body" media="all" href="$path/css/seckit.no_body.css" />
+      <!-- stop SecKit protection -->
+      <noscript>
+      <link type="text/css" rel="stylesheet" id="seckit-clickjacking-noscript-tag" media="all" href="$path/css/seckit.noscript_tag.css" />
+      <div id="seckit-noscript-tag">
+        <h1>$message</h1>
+      </div>
+      </noscript>
+      <script type="text/javascript">
+      <!--//--><![CDATA[//><!--
+      // open script tag to avoid syntax errors
+EOT;
+}
+
+/**
+ * Sends From-Origin HTTP response header.
+ *
+ * Implementation is based on specification draft
+ * available at http://www.w3.org/TR/from-origin.
+ */
+function _seckit_from_origin() {
+  $options = _seckit_get_options();
+  $value = $options['seckit_various']['from_origin_destination'];
+  drupal_add_http_header('From-Origin', $value);
+}
+
+/**
+ * Sends Strict-Transport-Security HTTP header
+ *
+ * HTTP Strict-Transport-Security (HSTS) header prevents eavesdropping and MITM attacks like SSLStrip,
+ * forces user-agent to send requests in HTTPS-only mode and convert HTTP links into secure.
+ *
+ * Implementation of HSTS is based on the specification draft available at
+ * http://tools.ietf.org/html/draft-hodges-strict-transport-sec-02
+ */
+function _seckit_hsts() {
+  // get default/set options
+  $options = _seckit_get_options();
+  // prepare HSTS header value
+  $max_age = $options['seckit_ssl']['hsts_max_age'];
+  $subdomains = $options['seckit_ssl']['hsts_subdomains'];
+  $header[] = "max-age=$max_age";
+  if ($subdomains) {
+    $header[] = 'includeSubDomains';
+  }
+  $header = implode('; ', $header);
+  // send HSTS header
+  drupal_add_http_header('Strict-Transport-Security', $header);
+}
+
+/**
+ * Converts a multi-line configuration option to an array.
+ * Sanitises by trimming whitespace, and filtering empty options.
+ */
+function _seckit_explode_value($string) {
+  $values = explode("\n", $string);
+  return array_values(array_filter(array_map('trim', $values)));
+}
+
+/**
+ * Sets default options.
+ *
+ * @param boolean $reset
+ *   If TRUE then re-generate (and re-cache) the options.
+ *
+ * @param boolean $alter
+ *   Whether to invoke hook_seckit_options_alter().
+ *   (Used internally to prevent altered values being used
+ *   in the admin settings form.)
+ */
+function _seckit_get_options($reset = FALSE, $alter = TRUE) {
+  $result = &drupal_static(__FUNCTION__, array());
+  if ($reset) {
+    $result = array();
+  }
+  elseif ($result) {
+    return $result;
+  }
+
+  // set default options
+  $default['seckit_xss']['csp'] = array(
+    'report-only' => 0,
+    'script-src'  => '',
+    'object-src'  => '',
+    'img-src'     => '',
+    'media-src'   => '',
+    'style-src'   => '',
+    'frame-src'   => '',
+    'font-src'    => '',
+    'connect-src' => '',
+    'policy-uri'  => '',
+  );
+  $default['seckit_csrf'] = array(
+    'origin'           => 1,
+    'origin_whitelist' => '',
+  );
+  $default['seckit_clickjacking'] = array(
+    'js_css_noscript' => 0,
+    'x_frame_allow_from' => '',
+  );
+  $default['seckit_ssl'] = array(
+    'hsts'            => 0,
+    'hsts_subdomains' => 0,
+  );
+  $default['seckit_various'] = array(
+    'from_origin' => 0,
+  );
+  // get variables
+  $result['seckit_xss']          = variable_get('seckit_xss', $default['seckit_xss']);
+  $result['seckit_csrf']         = variable_get('seckit_csrf', $default['seckit_csrf']);
+  $result['seckit_clickjacking'] = variable_get('seckit_clickjacking', $default['seckit_clickjacking']);
+  $result['seckit_ssl']          = variable_get('seckit_ssl', $default['seckit_ssl']);
+  $result['seckit_various']      = variable_get('seckit_various', $default['seckit_various']);
+  // enable Content Security Policy (CSP)
+  if (!isset($result['seckit_xss']['csp']['checkbox'])) {
+    $result['seckit_xss']['csp']['checkbox'] = 0;
+  }
+  // set CSP default-src directive to self
+  if (!isset($result['seckit_xss']['csp']['default-src']) || !$result['seckit_xss']['csp']['default-src']) {
+    $result['seckit_xss']['csp']['default-src'] = "'self'";
+  }
+  // set CSP report-uri directive to menu callback
+  if (!isset($result['seckit_xss']['csp']['report-uri']) || !$result['seckit_xss']['csp']['report-uri']) {
+    $result['seckit_xss']['csp']['report-uri'] = 'admin/config/system/seckit/csp-report';
+  }
+  // set X-XSS-Protection header to disabled (browser default).
+  if (!isset($result['seckit_xss']['x_xss']['select'])) {
+    $result['seckit_xss']['x_xss']['select'] = SECKIT_X_XSS_DISABLE;
+  }
+  // enable X-Content-Type-Options
+  if (!isset($result['seckit_xss']['x_content_type']['checkbox'])) {
+    $result['seckit_xss']['x_content_type']['checkbox'] = 1;
+  }
+  // enable Origin-based protection
+  if (!isset($result['seckit_csrf']['origin'])) {
+    $result['seckit_csrf']['origin'] = 1;
+  }
+  // set X-Frame-Options header to SameOrigin
+  if (!isset($result['seckit_clickjacking']['x_frame'])) {
+    $result['seckit_clickjacking']['x_frame'] = SECKIT_X_FRAME_SAMEORIGIN;
+  }
+  $x_frame_allow_from =& $result['seckit_clickjacking']['x_frame_allow_from'];
+  $x_frame_allow_from = _seckit_explode_value($x_frame_allow_from);
+
+  // set Custom text for disabled JavaScript message
+  if (!isset($result['seckit_clickjacking']['noscript_message'])) {
+    $result['seckit_clickjacking']['noscript_message'] = t('Sorry, you need to enable JavaScript to visit this website.');
+  }
+  // set HSTS max-age to 1000
+  if (!isset($result['seckit_ssl']['hsts_max_age'])) {
+    $result['seckit_ssl']['hsts_max_age'] = 1000;
+  }
+  // set From-Origin to same
+  if (!isset($result['seckit_various']['from_origin_destination'])) {
+    $result['seckit_various']['from_origin_destination'] = 'same';
+  }
+
+  if ($alter) {
+    drupal_alter('seckit_options', $result);
+  }
+  return $result;
+}

--- a/docroot/sites/all/modules/contrib/seckit/seckit.test
+++ b/docroot/sites/all/modules/contrib/seckit/seckit.test
@@ -1,0 +1,345 @@
+<?php
+/**
+ * @file
+ * Tests for Security Kit module.
+ */
+
+/**
+ * Functional tests for Security Kit.
+ */
+class SecKitTestCase extends DrupalWebTestCase {
+  /**
+   * Admin user for tests
+   * @var object
+   */
+  private $admin;
+
+  /**
+   * Implements getInfo().
+   * @see DrupalWebTestCase::getInfo()
+   */
+  public static function getInfo() {
+    return array(
+      'name' => t('Security Kit functionality'),
+      'description' => t('Tests functionality and settings page of Security Kit module.'),
+      'group' => t('Security Kit'),
+    );
+  }
+
+  /**
+   * Implements setUp().
+   * @see DrupalWebTestCase::setUp()
+   */
+  public function setUp() {
+    parent::setUp('seckit');
+    $this->admin = $this->drupalCreateUser(array('administer seckit'));
+    $this->drupalLogin($this->admin);
+  }
+
+  /**
+   * Tests disabled Content Security Policy.
+   */
+  public function testDisabledCSP() {
+    $form['seckit_xss[csp][checkbox]'] = FALSE;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertFalse($this->drupalGetHeader('Content-Security-Policy'),
+      t('Content Security Policy is disabled (Official).'));
+    $this->assertFalse($this->drupalGetHeader('X-Content-Security-Policy'),
+      t('Content Security Policy is disabled (Mozilla and IE10).'));
+    $this->assertFalse($this->drupalGetHeader('X-WebKit-CSP'),
+      t('Content Security Policy is disabled (Chrome and Safari).'));
+  }
+
+  /**
+   * Tests Content Security Policy with all enabled directives.
+   */
+  public function testCSPHasAllDirectives() {
+    $form = array(
+      'seckit_xss[csp][checkbox]'    => TRUE,
+      'seckit_xss[csp][default-src]' => '*',
+      'seckit_xss[csp][script-src]'  => '*',
+      'seckit_xss[csp][object-src]'  => '*',
+      'seckit_xss[csp][style-src]'   => '*',
+      'seckit_xss[csp][img-src]'     => '*',
+      'seckit_xss[csp][media-src]'   => '*',
+      'seckit_xss[csp][frame-src]'   => '*',
+      'seckit_xss[csp][font-src]'    => '*',
+      'seckit_xss[csp][connect-src]' => '*',
+      'seckit_xss[csp][report-uri]'  => 'admin/config/system/seckit/csp-report',
+    );
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $expected = 'default-src *; script-src *; object-src *; style-src *; img-src *; media-src *; frame-src *; font-src *; connect-src *; report-uri admin/config/system/seckit/csp-report';
+    $this->assertEqual($expected, $this->drupalGetHeader('Content-Security-Policy'),
+      t('Content-Security-Policy has all the directves (Official).'));
+    $this->assertEqual($expected, $this->drupalGetHeader('X-Content-Security-Policy'),
+      t('X-Content-Security-Policy has all the directves (Mozilla and IE10).'));
+    $this->assertEqual($expected, $this->drupalGetHeader('X-WebKit-CSP'),
+      t('X-WebKit-CSP has all the directves (Chrome and Safari).'));
+  }
+
+  /**
+   * Tests Content Security Policy with policy-uri directive.
+   * In this case, only policy-uri directive should be present.
+   */
+  public function testCSPPolicyUriDirectiveOnly() {
+    $form = array(
+      'seckit_xss[csp][checkbox]'    => TRUE,
+      'seckit_xss[csp][default-src]' => '*',
+      'seckit_xss[csp][script-src]'  => '*',
+      'seckit_xss[csp][object-src]'  => '*',
+      'seckit_xss[csp][style-src]'   => '*',
+      'seckit_xss[csp][img-src]'     => '*',
+      'seckit_xss[csp][media-src]'   => '*',
+      'seckit_xss[csp][frame-src]'   => '*',
+      'seckit_xss[csp][font-src]'    => '*',
+      'seckit_xss[csp][connect-src]' => '*',
+      'seckit_xss[csp][report-uri]'  => 'admin/config/system/seckit/csp-report',
+      'seckit_xss[csp][policy-uri]'  => 'http://mysite.com/csp.xml',
+    );
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $expected = 'policy-uri http://mysite.com/csp.xml';
+    $this->assertEqual($expected, $this->drupalGetHeader('Content-Security-Policy'),
+      t('Content-Security-Policy has only policy-uri (Official).'));
+    $this->assertEqual($expected, $this->drupalGetHeader('X-Content-Security-Policy'),
+      t('X-Content-Security-Policy has only policy-uri (Mozilla and IE10).'));
+    $this->assertEqual($expected, $this->drupalGetHeader('X-WebKit-CSP'),
+      t('X-WebKit-CSP has only policy-uri(Chrome and Safari).'));
+  }
+
+  /**
+   * Tests Content Security Policy with all directives empty.
+   * In this case, we should revert back to default values.
+   */
+  public function testCSPAllDirectivesEmpty() {
+    $form = array(
+      'seckit_xss[csp][checkbox]'    => TRUE,
+      'seckit_xss[csp][default-src]' => '',
+      'seckit_xss[csp][script-src]'  => '',
+      'seckit_xss[csp][object-src]'  => '',
+      'seckit_xss[csp][img-src]'     => '',
+      'seckit_xss[csp][media-src]'   => '',
+      'seckit_xss[csp][style-src]'   => '',
+      'seckit_xss[csp][frame-src]'   => '',
+      'seckit_xss[csp][font-src]'    => '',
+      'seckit_xss[csp][connect-src]' => '',
+      'seckit_xss[csp][report-uri]'  => '',
+      'seckit_xss[csp][policy-uri]'  => '',
+    );
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $expected = "default-src 'self'; report-uri admin/config/system/seckit/csp-report";
+    $this->assertEqual($expected, $this->drupalGetHeader('Content-Security-Policy'),
+      t('Content-Security-Policy has default directive (Official).'));
+    $this->assertEqual($expected, $this->drupalGetHeader('X-Content-Security-Policy'),
+      t('X-Content-Security-Policy has default directive (Mozilla and IE10).'));
+    $this->assertEqual($expected, $this->drupalGetHeader('X-WebKit-CSP'),
+      t('X-WebKit-CSP has default directive (Chrome and Safari).'));
+  }
+
+  /**
+   * Tests Content Security Policy in report-only mode.
+   */
+  public function testReportOnlyCSP() {
+    $form['seckit_xss[csp][checkbox]'] = TRUE;
+    $form['seckit_xss[csp][report-only]'] = TRUE;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertTrue($this->drupalGetHeader('Content-Security-Policy-Report-Only'),
+      t('Content Security Policy is in report-only mode (Official).'));
+    $this->assertTrue($this->drupalGetHeader('X-Content-Security-Policy-Report-Only'),
+      t('Content Security Policy is in report-only mode (Mozilla and IE10).'));
+    $this->assertTrue($this->drupalGetHeader('X-WebKit-CSP-Report-Only'),
+      t('Content Security Policy is in report-only mode (Chrome and Safari).'));
+  }
+
+  /**
+   * Tests disabled X-XSS-Protection HTTP response header.
+   */
+  public function testXXSSProtectionIsDisabled() {
+    $form['seckit_xss[x_xss][select]'] = SECKIT_X_XSS_DISABLE;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertFalse($this->drupalGetHeader('X-XSS-Protection'),
+      t('X-XSS-Protection is disabled.'));
+  }
+
+  /**
+   * Tests set to 0 X-XSS-Protection HTTP response header.
+   */
+  public function testXXSSProtectionIs0() {
+    $form['seckit_xss[x_xss][select]'] = SECKIT_X_XSS_0;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertEqual(0, $this->drupalGetHeader('X-XSS-Protection'),
+      t('X-XSS-Protection is set to 0.'));
+  }
+
+  /**
+   * Tests set to 1; mode=block X-XSS-Protection HTTP response header.
+   */
+  public function testXXSSProtectionIs1() {
+    $form['seckit_xss[x_xss][select]'] = SECKIT_X_XSS_1;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertEqual('1; mode=block', $this->drupalGetHeader('X-XSS-Protection'),
+      t('X-XSS-Protection is set to 1; mode=block.'));
+  }
+
+  /**
+   * Tests disabled X-Content-Type-Options HTTP response header.
+   */
+  public function testDisabledXContentTypeOptions() {
+    $form['seckit_xss[x_content_type][checkbox]'] = FALSE;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertFalse($this->drupalGetHeader('X-Content-Type-Options'),
+      t('X-Content-Type-Options is disabled.'));
+  }
+
+  /**
+   * Tests enabled X-Content-Type-Options HTTP response header.
+   */
+  public function testEnabledXContentTypeOptions() {
+    $form['seckit_xss[x_content_type][checkbox]'] = TRUE;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertEqual('nosniff', $this->drupalGetHeader('X-Content-Type-Options'),
+      t('X-Content-Type-Options is enabled and set to nosniff.'));
+  }
+
+  /**
+   * Tests HTTP Origin allows requests from the site.
+   */
+  public function testOriginAllowsSite() {
+    global $base_url;
+    $form['seckit_csrf[origin]'] = TRUE;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'),
+      array(), array('Origin: ' . $base_url));
+    $this->assertResponse(200,
+      t('Request is allowed.'));
+  }
+
+  /**
+   * Tests HTTP Origin allows requests from the specified source.
+   */
+  public function testOriginAllowsSpecifiedSource() {
+    $form = array(
+      'seckit_csrf[origin]' => TRUE,
+      'seckit_csrf[origin_whitelist]' => 'http://www.example.com',
+    );
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'),
+      array(), array('Origin: http://www.example.com'));
+    $this->assertResponse(200,
+      t('Whitelisted request is allowed.'));
+  }
+
+  /**
+   * Tests HTTP Origin denies request.
+   */
+  public function testOriginDeny() {
+    $form['seckit_csrf[origin]'] = TRUE;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'),
+      array(), array('Origin: http://www.example.com'));
+    $this->assertEqual(array(), $_POST,
+      t('POST is empty.'));
+    $this->assertResponse(403,
+      t('Request is denied.'));
+  }
+
+  /**
+   * Tests disabled X-Frame-Options HTTP response header.
+   */
+  public function testXFrameOptionsIsDisabled() {
+    $form['seckit_clickjacking[x_frame]'] = SECKIT_X_FRAME_DISABLE;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertFalse($this->drupalGetHeader('X-Frame-Options'),
+      t('X-Frame-Options is disabled.'));
+  }
+
+  /**
+   * Tests set to SameOrigin X-Frame-Options HTTP response header.
+   */
+  public function testXFrameOptionsIsSameOrigin() {
+    $form['seckit_clickjacking[x_frame]'] = SECKIT_X_FRAME_SAMEORIGIN;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertEqual('SameOrigin', $this->drupalGetHeader('X-Frame-Options'),
+      t('X-Frame-Options is set to SameOrigin.'));
+  }
+
+  /**
+   * Tests set to Deny X-Frame-Options HTTP response header.
+   */
+  public function testXFrameOptionsIsDeny() {
+    $form['seckit_clickjacking[x_frame]'] = SECKIT_X_FRAME_DENY;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertEqual('Deny', $this->drupalGetHeader('X-Frame-Options'),
+      t('X-Frame-Options is set to Deny.'));
+  }
+
+  /**
+   * Tests set to Allow-From X-Frame-Options HTTP response header.
+   */
+  public function testXFrameOptionsIsAllowFrom() {
+    $form['seckit_clickjacking[x_frame]'] = SECKIT_X_FRAME_ALLOW_FROM;
+    $form['seckit_clickjacking[x_frame_allow_from]'] = 'http://www.google.com';
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertEqual('Allow-From: http://www.google.com', $this->drupalGetHeader('X-Frame-Options'),
+      t('X-Frame-Options is set to Allow-From.'));
+  }
+
+  /**
+   * Tests JS + CSS + Noscript protection.
+   */
+  public function testJSCSSNoscript() {
+    $form['seckit_clickjacking[js_css_noscript]'] = TRUE;
+    $form['seckit_clickjacking[noscript_message]'] = 'Sorry, your JavaScript is disabled.';
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $code = _seckit_get_js_css_noscript_code();
+    $this->assertRaw($code,
+      t('JavaScript + CSS + Noscript protection is loaded.'));
+  }
+
+  /**
+   * Tests disabled HTTP Strict Transport Security.
+   */
+  public function testDisabledHSTS() {
+    $form['seckit_ssl[hsts]'] = FALSE;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertFalse($this->drupalGetHeader('Strict-Transport-Security'),
+      t('HTTP Strict Transport Security is disabled.'));
+  }
+
+  /**
+   * Tests HTTP Strict Transport Security has all directives.
+   */
+  public function testHSTSAllDirectves() {
+    $form = array(
+      'seckit_ssl[hsts]' => TRUE,
+      'seckit_ssl[hsts_max_age]' => 1000,
+      'seckit_ssl[hsts_subdomains]' => 1,
+    );
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $expected = 'max-age=1000; includeSubDomains';
+    $this->assertEqual($expected, $this->drupalGetHeader('Strict-Transport-Security'),
+      t('HTTP Strict Transport Security has all the directives.'));
+  }
+
+  /**
+   * Tests disabled From-Origin.
+   */
+  public function testDisabledFromOrigin() {
+    $form['seckit_various[from_origin]'] = FALSE;
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertFalse($this->drupalGetHeader('From-Origin'),
+      t('From-Origin is disabled.'));
+  }
+
+  /**
+   * Tests enabled From-Origin.
+   */
+  public function testEnabledFromOrigin() {
+    $form = array(
+      'seckit_various[from_origin]' => TRUE,
+      'seckit_various[from_origin_destination]' => 'same',
+    );
+    $this->drupalPost('admin/config/system/seckit', $form, t('Save configuration'));
+    $this->assertEqual('same', $this->drupalGetHeader('From-Origin'),
+      t('From-Origin is enabled and set to same.'));
+  }
+}


### PR DESCRIPTION
## Description 
Http Strict Transport Security (HSTS) policy enables web applications to enforce web browsers to restrict communication with the server over an encrypted SSL/TLS connection for a set period. Policy is declared via special Strict Transport Security response header. Encrypted connection protects sensitive user and session data from attackers eavesdropping on network connection.
A successful MiTM attack can lead to the compromise of sensitive user data as well as grant unauthorized access to user accounts enabling attackers to perform privileged actions on client’s behalf.

## Solution

@topicus added the seckit module as @acouch proposed.

## QA steps

- update config.yml to set default:seckit:enable to true.
- run ahoy build config
- run ahoy site up
- Open the chrome developer tools and click in the network tab
- Click on the page request and verify the Strict-Transport-Security header is present in the list of reponse headers