### PR TITLE
Document role_watchdog inclusion

### DIFF
--- a/docs/modules/index.rst
+++ b/docs/modules/index.rst
@@ -1,5 +1,5 @@
 DKAN Starter Modules
---------------------
+====================
 
 DKAN Starter includes several modules that are not in DKAN.
 
@@ -15,3 +15,10 @@ These modules help the build process for maintaining sites built with DKAN.
    features-banish
    features-master
    features-override
+
+Helper modules
+--------------
+
+These modules simply provide additional functionality that has proved useful in real-world DKAN deployments, but was not crucial enough to include in the core DKAN package:
+
+- `Role Watchdog <https://www.drupal.org/project/role_watchdog>`_


### PR DESCRIPTION
Adds a section to the "modules" section of DKAN Starter docs.